### PR TITLE
fix: remove fixed calendar in top

### DIFF
--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -1,7 +1,6 @@
 <template>
 	<v-menu
 		ref="menuField"
-		content-class="calendar__container"
 		v-model="menuField"
 		:close-on-content-click="false"
 		:return-value.sync="fieldRange"
@@ -168,8 +167,5 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .theme--light.v-input.v-input--dense.v-text-field.v-text-field--outlined.error--text:after {
 	content: '' !important;
-}
-.calendar__container {
-	top: 56px !important;
 }
 </style>


### PR DESCRIPTION
Removendo está alteração pois no teste no front-mfe-cadastros, o mesmo ficou desalinhado e fixado no topo do input.