### PR TITLE
feat: init structure for stepper header

### DIFF
--- a/src/components/ModalPromptUser/ModalPromptUser.vue
+++ b/src/components/ModalPromptUser/ModalPromptUser.vue
@@ -102,6 +102,6 @@ export default Vue.extend({
 			this.$emit('onConfirm');
 			this.inputVal = false;
 		},
-	}
+	},
 });
 </script>

--- a/src/components/Stepper/StepperHeader/IStep.ts
+++ b/src/components/Stepper/StepperHeader/IStep.ts
@@ -1,0 +1,6 @@
+interface IStep {
+	label: string;
+	icon?: string;
+}
+
+export default IStep;

--- a/src/components/Stepper/StepperHeader/StepperHeader.scss
+++ b/src/components/Stepper/StepperHeader/StepperHeader.scss
@@ -12,12 +12,15 @@ $step-height: 64px;
 		flex-direction: column;
 		align-items: center;
 		border: 1px solid gray;
+
 		&.stepper__header-step--previous {
-			border-color: green;
+			border-color: #009900;
 		}
+
 		&.stepper__header-step--current {
 			border-color: yellow;
 		}
+
 		&.stepper__header-step--error {
 			border-color: red;
 			color: red;

--- a/src/components/Stepper/StepperHeader/StepperHeader.scss
+++ b/src/components/Stepper/StepperHeader/StepperHeader.scss
@@ -1,0 +1,59 @@
+$step-height: 64px;
+
+.stepper__header {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+
+	div.stepper__header-step {
+		width: 80px;
+		height: $step-height;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		border: 1px solid gray;
+		&.stepper__header-step--previous {
+			border-color: green;
+		}
+		&.stepper__header-step--current {
+			border-color: yellow;
+		}
+		&.stepper__header-step--error {
+			border-color: red;
+			color: red;
+		}
+
+		.mdi {
+			font-size: 20px;
+		}
+	}
+
+	.stepper__divider--previous {
+		border-color: green;
+	}
+
+	hr {
+		display: block;
+		flex: 1 1 0px;
+		max-width: 100%;
+		height: 0;
+		max-height: 0;
+		margin-top: $step-height/2;
+		border: none;
+		border-bottom: 1px solid gray;
+	}
+
+	&.stepper__header--vertical {
+		flex-direction: column;
+
+		hr {
+			height: 16px;
+		}
+
+		.stepper__divider--vertical {
+			height: 32px;
+			border-left: 1px solid gray;
+			margin-left: 40px;
+		}
+	}
+}

--- a/src/components/Stepper/StepperHeader/StepperHeader.stories.js
+++ b/src/components/Stepper/StepperHeader/StepperHeader.stories.js
@@ -3,6 +3,16 @@ import StepperHeader from './StepperHeader.vue';
 export default {
 	title: 'API/Stepper/StepperHeader',
 	component: StepperHeader,
+	parameters: {
+		docs: {
+			description: {
+				component: `Stepper Header<br />
+				selector: <em>farm-stepper-header</em>
+				`,
+			},
+		},
+		viewMode: 'docs',
+	},
 };
 
 export const Primary = () => ({
@@ -21,36 +31,4 @@ export const Primary = () => ({
 	template: '<StepperHeader :steps="steps" :currentStep="currentStep" />',
 });
 
-export const Error = () => ({
-	components: { StepperHeader },
-	data() {
-		return {
-			steps: [
-				{ label: 'Step 1', icon: '' },
-				{ label: 'Step 2', icon: 'monitor' },
-				{ label: 'Step 3', icon: 'book' },
-				{ label: 'Step 4', icon: '' },
-			],
-			currentStep: 3,
-		};
-	},
-	template: '<StepperHeader :steps="steps" :currentStep="currentStep" :errorCurrentStepStatus="true" />',
-});
-
-export const Vertical = () => ({
-	components: { StepperHeader },
-	data() {
-		return {
-			steps: [
-				{ label: 'Step 1', icon: '' },
-				{ label: 'Step 2', icon: '' },
-				{ label: 'Step 3', icon: '' },
-			],
-		};
-	},
-	template: '<StepperHeader :steps="steps" vertical />',
-});
-
 Primary.storyName = 'Básico';
-Vertical.storyName = 'Vertical';
-Error.storyName = 'Com Erro';

--- a/src/components/Stepper/StepperHeader/StepperHeader.stories.js
+++ b/src/components/Stepper/StepperHeader/StepperHeader.stories.js
@@ -1,0 +1,56 @@
+import StepperHeader from './StepperHeader.vue';
+
+export default {
+	title: 'API/Stepper/StepperHeader',
+	component: StepperHeader,
+};
+
+export const Primary = () => ({
+	components: { StepperHeader },
+	data() {
+		return {
+			steps: [
+				{ label: 'Step 1', icon: '' },
+				{ label: 'Step 2', icon: 'monitor' },
+				{ label: 'Step 3', icon: 'book' },
+				{ label: 'Step 4', icon: '' },
+			],
+			currentStep: 3,
+		};
+	},
+	template: '<StepperHeader :steps="steps" :currentStep="currentStep" />',
+});
+
+export const Error = () => ({
+	components: { StepperHeader },
+	data() {
+		return {
+			steps: [
+				{ label: 'Step 1', icon: '' },
+				{ label: 'Step 2', icon: 'monitor' },
+				{ label: 'Step 3', icon: 'book' },
+				{ label: 'Step 4', icon: '' },
+			],
+			currentStep: 3,
+		};
+	},
+	template: '<StepperHeader :steps="steps" :currentStep="currentStep" :errorCurrentStepStatus="true" />',
+});
+
+export const Vertical = () => ({
+	components: { StepperHeader },
+	data() {
+		return {
+			steps: [
+				{ label: 'Step 1', icon: '' },
+				{ label: 'Step 2', icon: '' },
+				{ label: 'Step 3', icon: '' },
+			],
+		};
+	},
+	template: '<StepperHeader :steps="steps" vertical />',
+});
+
+Primary.storyName = 'Básico';
+Vertical.storyName = 'Vertical';
+Error.storyName = 'Com Erro';

--- a/src/components/Stepper/StepperHeader/StepperHeader.vue
+++ b/src/components/Stepper/StepperHeader/StepperHeader.vue
@@ -1,0 +1,70 @@
+<template>
+	<section :class="{ stepper__header: true, 'stepper__header--vertical': vertical }">
+		<template v-for="(step, index) in steps">
+			<div
+				:class="{
+					'stepper__header-step': true,
+					'stepper__header-step--current': isStepCurrent(index),
+					'stepper__header-step--previous': isStepPrevious(index),
+					'stepper__header-step--error': isStepError(index),
+				}"
+				:key="step.label"
+			>
+				{{ step.label }}
+				<i
+					:class="{
+						mdi: true,
+						['mdi-' + step.icon]: true,
+					}"
+					v-if="step.icon"
+				></i>
+			</div>
+			<hr
+				:class="{
+					'stepper__divider--previous': isStepCurrent(index),
+				}"
+				v-if="!vertical && hasDivider(index)"
+				:key="'divider_' + step.label"
+			/>
+			<div
+				:class="{
+					'stepper__divider--vertical': true,
+					'stepper__divider--previous': isStepCurrent(index),
+				}"
+				v-if="vertical && hasDivider(index)"
+				:key="'divider_' + step.label"
+			/>
+		</template>
+	</section>
+</template>
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import IStep from './IStep';
+
+export default Vue.extend({
+	name: 'farm-stepper-header',
+	props: {
+		steps: Array as PropType<Array<IStep>>,
+		vertical: Boolean,
+		currentStep: Number,
+		errorCurrentStepStatus: Boolean,
+	},
+	methods: {
+		isStepCurrent(index: number): boolean {
+			return this.currentStep === index + 1;
+		},
+		isStepPrevious(index: number): boolean {
+			return this.currentStep > index + 1;
+		},
+		isStepError(index: number): boolean {
+			return this.currentStep === index + 1 && this.errorCurrentStepStatus;
+		},
+		hasDivider(index: number): boolean {
+			return index < this.steps.length - 1;
+		},
+	},
+});
+</script>
+<style lang="sass" scoped>
+@import './StepperHeader.scss'
+</style>

--- a/src/components/Stepper/StepperHeader/StepperHeader.vue
+++ b/src/components/Stepper/StepperHeader/StepperHeader.vue
@@ -44,10 +44,23 @@ import IStep from './IStep';
 export default Vue.extend({
 	name: 'farm-stepper-header',
 	props: {
+		/**
+		 * Steps
+		 * Implements IStep
+		 */
 		steps: Array as PropType<Array<IStep>>,
-		vertical: Boolean,
-		currentStep: Number,
-		errorCurrentStepStatus: Boolean,
+		/**
+		 * Vertical or horizontal
+		 */
+		vertical: { type: Boolean, default: false },
+		/**
+		 * Current step
+		 */
+		currentStep: { type: Number },
+		/**
+		 * Is current step in error status?
+		 */
+		errorCurrentStepStatus: { type: Boolean, default: false },
 	},
 	methods: {
 		isStepCurrent(index: number): boolean {

--- a/src/components/Stepper/StepperHeader/__tests__/StepperHeader.spec.js
+++ b/src/components/Stepper/StepperHeader/__tests__/StepperHeader.spec.js
@@ -1,0 +1,47 @@
+import { shallowMount } from '@vue/test-utils';
+import StepperHeader from '../StepperHeader';
+
+describe('StepperHeader component', () => {
+	let wrapper;
+	let component;
+
+	beforeEach(() => {
+		wrapper = shallowMount(StepperHeader, {
+			propsData: {
+				steps: [
+					{ label: 'Step 1', icon: '' },
+					{ label: 'Step 2', icon: 'monitor' },
+					{ label: 'Step 3', icon: 'book' },
+					{ label: 'Step 4', icon: '' },
+				],
+				currentStep: 3,
+			},
+		});
+		component = wrapper.vm;
+	});
+
+	test('StepperHeader created', () => {
+		expect(wrapper).toBeDefined();
+	});
+
+	describe('Methods', () => {
+		it('Should check if step is current', () => {
+			expect(component.isStepCurrent(1)).toBeFalsy();
+			expect(component.isStepCurrent(2)).toBeTruthy();
+		});
+
+		it('Should check if step is previous', () => {
+			expect(component.isStepPrevious(1)).toBeTruthy();
+			expect(component.isStepPrevious(3)).toBeFalsy();
+		});
+
+		it('Should check if step is error', () => {
+			expect(component.isStepError(1)).toBeFalsy();
+		});
+
+		it('Should check if has divider', () => {
+			expect(component.hasDivider(4)).toBeFalsy();
+			expect(component.hasDivider(1)).toBeTruthy();
+		});
+	});
+});

--- a/src/components/Stepper/StepperHeader/index.ts
+++ b/src/components/Stepper/StepperHeader/index.ts
@@ -1,0 +1,4 @@
+import StepperHeader from './StepperHeader.vue';
+
+export { StepperHeader };
+export default StepperHeader;

--- a/src/components/Stepper/index.ts
+++ b/src/components/Stepper/index.ts
@@ -1,3 +1,5 @@
 import StepperHeader from './StepperHeader/StepperHeader.vue';
 
-export default { StepperHeader };
+export { StepperHeader };
+
+

--- a/src/components/Stepper/index.ts
+++ b/src/components/Stepper/index.ts
@@ -1,0 +1,3 @@
+import StepperHeader from './StepperHeader/StepperHeader.vue';
+
+export default { StepperHeader };

--- a/src/examples/Stepper/StepperHeader.stories.js
+++ b/src/examples/Stepper/StepperHeader.stories.js
@@ -1,0 +1,65 @@
+import { StepperHeader } from '../../main';
+
+const steps = [
+	{ label: 'Step 1', icon: '' },
+	{ label: 'Step 2', icon: 'monitor' },
+	{ label: 'Step 3', icon: 'book' },
+	{ label: 'Step 4', icon: '' },
+];
+
+export default {
+	title: 'Examples/Stepper/StepperHeader',
+	component: StepperHeader,
+	parameters: {
+		viewMode: 'docs',
+		docs: {
+			description: {
+				component: `StepperHeader`,
+			},
+		},
+	},
+};
+
+export const Primary = () => ({
+	components: { StepperHeader },
+	data() {
+		return {
+			steps,
+			currentStep: 3,
+		};
+	},
+	template: '<StepperHeader :steps="steps" :currentStep="currentStep" />',
+});
+
+export const Error = () => ({
+	components: { StepperHeader },
+	data() {
+		return {
+			steps,
+			currentStep: 3,
+		};
+	},
+	template:
+		'<StepperHeader :steps="steps" :currentStep="currentStep" :errorCurrentStepStatus="true" />',
+});
+
+export const Vertical = () => ({
+	components: { StepperHeader },
+	data() {
+		return {
+			steps,
+			currentStep: 3,
+		};
+	},
+	template: '<StepperHeader :steps="steps" :currentStep="currentStep" vertical />',
+});
+
+Primary.story = {
+	name: 'Básico',
+};
+Vertical.story = {
+	name: 'Vertical',
+};
+Error.story = {
+	name: 'Error',
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,3 +59,4 @@ export * from './components/ResetTableRowSelection';
 export * from './components/MultipleSelectShortener';
 export * from './components/SelectModalOptions';
 export * from './components/ChipInviteStatus';
+export * from './components/Stepper';


### PR DESCRIPTION
@Dirceu-Souza-Rezende @everton-ribeiro conforme combinamos antes, vamos no projeto de componente deixar de usar o Vuetify nos novos componentes que precisaremos criar.
No Design System aparecerá um componente de stepper. Ainda estão prototipando e acertando design. Ele será usado no futuro próximo no workflow da solicitação de limite (squad de crédito) mas vamos ver se usarão em outros lugares - quem sabe nos formulários @everton-ribeiro .
Com isso, montei a estrutura básica dele pra depois trabalharmos, quando entrar na sprint, e ter o esqueleto. Além disso, aproveitei pra testar o processo de não usar Vuetify (pra usar ícone, por exemplo, é só usar a tag i com a classe mdi, padrão do fontawesome).
Pra acessar a API, tem storybook já:
http://localhost:6006/?path=/story/api-stepper-stepperheader--primary