### PR TITLE
refactor: dialog footer

### DIFF
--- a/src/components/DialogFooter/DialogFooter.scss
+++ b/src/components/DialogFooter/DialogFooter.scss
@@ -1,0 +1,29 @@
+@import '../../configurations/functions';
+
+.farm-dialog__footer {
+    border-top: 1px solid var(--v-gray-lighten2);
+    padding: 1rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+}
+
+.farm-btn {
+    margin-left: gutter();
+    margin-top: 0;
+}
+
+@media screen and (max-width: 600px) {
+    .farm-btn {
+        margin-left: 0;
+        margin-top: gutter();
+    }
+
+    .farm-dialog__footer {
+        flex-direction: column;
+
+        .farm-btn:first-of-type {
+            margin-top: 0;
+        }
+    }
+}

--- a/src/components/DialogFooter/DialogFooter.scss
+++ b/src/components/DialogFooter/DialogFooter.scss
@@ -1,4 +1,5 @@
 @import '../../configurations/functions';
+@import '../../configurations/mixins';
 
 .farm-dialog__footer {
     border-top: 1px solid var(--v-gray-lighten2);
@@ -13,7 +14,7 @@
     margin-top: 0;
 }
 
-@media screen and (max-width: 600px) {
+@include for-sm-breakpoint {
     .farm-btn {
         margin-left: 0;
         margin-top: gutter();

--- a/src/components/DialogFooter/DialogFooter.vue
+++ b/src/components/DialogFooter/DialogFooter.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="v-dialog__footer d-flex flex-column flex-sm-row justify-end">
-		<farm-btn @click="$emit('onClose')" v-if="hasCancel" color="primary" outlined>
+	<div class="farm-dialog__footer">
+		<farm-btn v-if="hasCancel" color="primary" outlined @click="$emit('onClose')">
 			{{ closeLabel }}
 		</farm-btn>
 		<farm-btn
@@ -8,15 +8,12 @@
 			:key="button.label"
 			:color="button.color"
 			:outlined="button.outlined"
-			:depressed="button.outlined"
 			:disabled="button.disabled"
-			class="ml-sm-3 mt-3 mt-sm-0"
 			@click="$emit(button.listener ? button.listener : '')"
 		>
 			{{ button.label }}
 		</farm-btn>
 		<farm-btn
-			class="ml-sm-3 mt-3 mt-sm-0"
 			v-if="hasConfirm"
 			:color="confirmColor"
 			:disabled="isConfirmDisabled"
@@ -28,13 +25,15 @@
 	</div>
 </template>
 
-<script>
+<script lang="ts">
+import Vue from 'vue';
 import DefaultButton from '../Buttons/DefaultButton';
+
 /**
  * Footer de dialog/modal
  */
-export default {
-	name: 'DialogFooter',
+export default Vue.extend({
+	name: 'farm-dialog-foote',
 	components: {
 		'farm-btn': DefaultButton,
 	},
@@ -96,5 +95,8 @@ export default {
 			default: () => [],
 		},
 	},
-};
+});
 </script>
+<style lang="scss" scoped>
+@import 'DialogFooter';
+</style>

--- a/src/components/DialogFooter/DialogFooter.vue
+++ b/src/components/DialogFooter/DialogFooter.vue
@@ -26,8 +26,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
 import DefaultButton from '../Buttons/DefaultButton';
+import IExtraButton from './IExtraButton';
 
 /**
  * Footer de dialog/modal
@@ -88,10 +89,10 @@ export default Vue.extend({
 			default: false,
 		},
 		/**
-		 * lista de botões extra
+		 * lista de botões extra (IExtraButton)
 		 */
 		extraButtons: {
-			type: Array,
+			type: Array as PropType<Array<IExtraButton>>,
 			default: () => [],
 		},
 	},

--- a/src/components/DialogFooter/IExtraButton.ts
+++ b/src/components/DialogFooter/IExtraButton.ts
@@ -1,0 +1,9 @@
+interface IExtraButton {
+	label: string;
+	color: string;
+	outlined: boolean;
+	disabled: boolean;
+	listener: Function | null;
+}
+
+export default IExtraButton;

--- a/src/configurations/_functions.scss
+++ b/src/configurations/_functions.scss
@@ -1,0 +1,5 @@
+@import './variables';
+
+@function gutter($key: 'default') {
+    @return map-get($gutters, $key)
+}

--- a/src/configurations/_mixins.scss
+++ b/src/configurations/_mixins.scss
@@ -1,0 +1,5 @@
+@mixin for-sm-breakpoint {
+    @media (max-width: 599px) {
+        @content;
+    }
+}

--- a/src/configurations/_variables.scss
+++ b/src/configurations/_variables.scss
@@ -1,2 +1,15 @@
 $colors: primary, secondary, error, extra, accent, info, success, gray, yellow, white;
-$sizes: ("xs": 12px, "sm": 16px , "md": 24px, "lg": 36px, "xl": 40px);
+$sizes: (
+    "xs": 12px,
+    "sm": 16px,
+    "md": 24px,
+    "lg": 36px,
+    "xl": 40px
+);
+$gutters: (
+    "xs": 4px,
+    'sm': 8px,
+    "default": 12px,
+    'md': 16px,
+    "lg": 36px,
+    "xl": 40px);


### PR DESCRIPTION
Refix o DialogFooter retirando qualquer referência ao vuetify. Aproveitei pra criar um mixin que recebe regras css para o breakpoint sm (até 600px) e uma função que retorna abstrai como setar o gutter/padding.