### PR TITLE
feat: STOR-120 & refactor STOR-108

### DIFF
--- a/src/components/ContextMenu/ContextMenu.scss
+++ b/src/components/ContextMenu/ContextMenu.scss
@@ -1,0 +1,32 @@
+@import '../../configurations/mixins';
+
+.farm-contextmenu {
+	display: inline-block;
+}
+
+.farm-contextmenu__popup {
+	visibility: hidden;
+	opacity: 0;
+	position: absolute;
+	display: block;
+	overflow-y: auto;
+	overflow-x: hidden;
+	contain: content;
+	font-family: 'Montserrat', sans-serif !important;
+
+	transform-origin: left top;
+	transition: visibility 0.1s linear, opacity 0.1s linear;
+
+	border-radius: 4px;
+	left: 0;
+
+	background: #FFFFFF;
+	border: 1px solid var(--farm-stroke-base);
+	@include addShadow;
+	border-radius: 5px;
+
+	&--visible {
+		opacity: 1;
+		visibility: visible;
+	}
+}

--- a/src/components/ContextMenu/ContextMenu.stories.js
+++ b/src/components/ContextMenu/ContextMenu.stories.js
@@ -1,0 +1,104 @@
+import { withDesign } from 'storybook-addon-designs';
+import ContextMenu from './';
+
+export default {
+	title: 'Interactions/ContextMenu',
+	component: ContextMenu,
+	decorators: [withDesign],
+	parameters: {
+		docs: {
+			description: {
+				component: `ContextMenu<br />
+				selector: <em>farm-contextmenu</em><br />
+				<span style="color: var(--farm-primary-base);">ready for use</span>
+				`,
+			},
+		},
+		viewMode: 'docs',
+	},
+};
+
+export const Primary = () => ({
+	data() {
+		return {
+			value: false,
+		};
+	},
+	methods: {
+		toggleValue() {
+			this.value = !this.value;
+		},
+	},
+	template: `<div style="padding-left: 120px; padding-top: 80px; display: flex;">
+        <farm-contextmenu v-model="value">
+            some text
+            <template v-slot:activator="{ on, attrs }">
+                <farm-btn @click="toggleValue">toggle</farm-btn>
+            </template>
+        </farm-contextmenu>
+	</div>`,
+});
+
+export const LongContent = () => ({
+	data() {
+		return {
+			value: false,
+		};
+	},
+	methods: {
+		toggleValue() {
+			this.value = !this.value;
+		},
+	},
+	template: `<div style="padding-left: 120px; padding-top: 80px;">
+        <farm-contextmenu v-model="value">
+            <div style="width: 160px">long content<br />
+			with breakline</div>
+            <template v-slot:activator="{ on, attrs }">
+                <farm-btn @click="toggleValue">toggle</farm-btn>
+            </template>
+        </farm-contextmenu>
+	</div>`,
+});
+
+export const Bottom = () => ({
+	data() {
+		return {
+			value: false,
+		};
+	},
+	methods: {
+		toggleValue() {
+			this.value = !this.value;
+		},
+	},
+	template: `<div style="padding-left: 120px; padding-top: 80px; display: flex;">
+        <farm-contextmenu v-model="value" :bottom="true">
+            some text
+            <template v-slot:activator="{ on, attrs }">
+                <farm-btn @click="toggleValue">toggle</farm-btn>
+            </template>
+        </farm-contextmenu>
+	</div>`,
+});
+
+export const ComplexContent = () => ({
+	data() {
+		return {
+			value: false,
+		};
+	},
+	methods: {
+		toggleValue() {
+			this.value = !this.value;
+		},
+	},
+	template: `<div style="padding-left: 120px; padding-top: 80px; display: flex;">
+        <farm-contextmenu v-model="value">
+            <farm-chip>farm chip</farm-chip>
+            <template v-slot:activator="{ on, attrs }">
+                <farm-btn @click="toggleValue">toggle</farm-btn>
+            </template>
+        </farm-contextmenu>
+	</div>`,
+});

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="{ 'farm-contextmenu': true }" ref="parent">
+	<div class="farm-contextmenu" ref="parent">
 		<span ref="activator">
 			<slot name="activator"></slot>
 		</span>

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -47,6 +47,8 @@ export default Vue.extend({
 
 		const inputValue = ref(props.value);
 
+		let hasBeenBoostrapped = false;
+
 		const outClick = (event: Event) => {
 			if (activator && !activator.value.contains(event.target)) {
 				emit('input', false);
@@ -61,7 +63,14 @@ export default Vue.extend({
 			() => props.value,
 			newValue => {
 				if (newValue) {
+					if (!hasBeenBoostrapped) {
+						document.querySelector('body').appendChild(popup.value);
+
+						hasBeenBoostrapped = true;
+					}
 					window.addEventListener('click', outClick);
+					window.addEventListener('resize', resizeWindowHandler);
+
 					calculatePosition();
 				} else {
 					window.removeEventListener('click', outClick);
@@ -93,15 +102,15 @@ export default Vue.extend({
 		};
 
 		onMounted(() => {
-			window.addEventListener('resize', resizeWindowHandler);
-			document.querySelector('body').appendChild(popup.value);
 			calculatePosition();
 		});
 
 		onBeforeUnmount(() => {
-			window.removeEventListener('resize', resizeWindowHandler);
-			window.removeEventListener('click', outClick);
-			document.querySelector('body').removeChild(popup.value);
+			if (hasBeenBoostrapped) {
+				window.removeEventListener('resize', resizeWindowHandler);
+				window.removeEventListener('click', outClick);
+				document.querySelector('body').removeChild(popup.value);
+			}
 		});
 
 		return {

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -1,0 +1,120 @@
+<template>
+	<div :class="{ 'farm-contextmenu': true }" ref="parent">
+		<span ref="activator">
+			<slot name="activator"></slot>
+		</span>
+
+		<div
+			ref="popup"
+			:class="{
+				'farm-contextmenu__popup': true,
+				'farm-contextmenu__popup--visible': inputValue,
+			}"
+			:style="styles"
+		>
+			<slot></slot>
+		</div>
+	</div>
+</template>
+<script lang="ts">
+import Vue, { onMounted, ref, watch, reactive, onBeforeUnmount, toRefs } from 'vue';
+
+export default Vue.extend({
+	name: 'farm-contextmenu',
+	props: {
+		/**
+		 * Control visibility
+		 * v-model bind
+		 */
+		value: {
+			type: Boolean,
+			default: undefined,
+		},
+		/**
+		 * Aligns the component towards the bottom
+		 */
+		bottom: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	setup(props, { emit }) {
+		const parent = ref(null);
+		const popup = ref(null);
+		const activator = ref(null);
+		const styles = reactive({ minWidth: 0, top: 0 } as any);
+		const { bottom } = toRefs(props);
+
+		const inputValue = ref(props.value);
+
+		const outClick = (event: Event) => {
+			if (activator && !activator.value.contains(event.target)) {
+				emit('input', false);
+			}
+		};
+
+		const resizeWindowHandler = () => {
+			calculatePosition();
+		};
+
+		watch(
+			() => props.value,
+			newValue => {
+				if (newValue) {
+					window.addEventListener('click', outClick);
+					calculatePosition();
+				} else {
+					window.removeEventListener('click', outClick);
+				}
+				inputValue.value = newValue;
+			}
+		);
+
+		const calculatePosition = () => {
+			const parentBoundingClientRect = parent.value.getBoundingClientRect();
+			const popupClientRect = popup.value.getBoundingClientRect();
+
+			const offsetTop =
+				parentBoundingClientRect.top +
+				window.scrollY +
+				(!bottom.value ? 0 : parentBoundingClientRect.height);
+
+			let offsetLeft = parentBoundingClientRect.left;
+			if (popupClientRect.width > parentBoundingClientRect.width) {
+				offsetLeft =
+					offsetLeft + parentBoundingClientRect.width / 2 - popupClientRect.width / 2;
+			}
+			styles.minWidth =
+				parentBoundingClientRect.width > 96
+					? parseInt(parentBoundingClientRect.width)
+					: 96 + 'px';
+			styles.top = offsetTop + 'px';
+			styles.left = offsetLeft + 'px';
+		};
+
+		onMounted(() => {
+			window.addEventListener('resize', resizeWindowHandler);
+			document.querySelector('body').appendChild(popup.value);
+			calculatePosition();
+		});
+
+		onBeforeUnmount(() => {
+			window.removeEventListener('resize', resizeWindowHandler);
+			window.removeEventListener('click', outClick);
+			document.querySelector('body').removeChild(popup.value);
+		});
+
+		return {
+			parent,
+			popup,
+			activator,
+			styles,
+			inputValue,
+		};
+	},
+});
+</script>
+
+<style lang="scss" scoped>
+@import './ContextMenu';
+</style>

--- a/src/components/ContextMenu/__tests__/ContextMenu.spec.js
+++ b/src/components/ContextMenu/__tests__/ContextMenu.spec.js
@@ -1,0 +1,20 @@
+import { shallowMount } from '@vue/test-utils';
+import ContextMenu from '../ContextMenu';
+
+describe('ContextMenu component', () => {
+	let wrapper;
+
+	beforeEach(() => {
+		wrapper = shallowMount(ContextMenu, {});
+	});
+
+	test('Created hook', () => {
+		expect(wrapper).toBeDefined();
+	});
+
+	describe('mount component', () => {
+		it('renders correctly', () => {
+			expect(wrapper.element).toMatchSnapshot();
+		});
+	});
+});

--- a/src/components/ContextMenu/index.ts
+++ b/src/components/ContextMenu/index.ts
@@ -1,0 +1,5 @@
+import ContextMenu from './ContextMenu.vue';
+
+export default ContextMenu;
+
+export { ContextMenu };

--- a/src/components/TableContextMenu/TableContextMenu.scss
+++ b/src/components/TableContextMenu/TableContextMenu.scss
@@ -1,10 +1,17 @@
-[role='menuitem'] {
+.v-list-item.v-list-item--link {
 	border-bottom: 1px solid var(--farm-stroke-base);
 }
 
 .v-list-item__title {
+	display: flex;
+	align-items: center;
 	.farm-icon {
 		vertical-align: sub;
 		margin-right: 8px;
 	}
+}
+
+::v-deep .v-application--wrap {
+	min-height: auto;
+	font-family: 'Montserrat', sans-serif !important;
 }

--- a/src/components/TableContextMenu/TableContextMenu.stories.js
+++ b/src/components/TableContextMenu/TableContextMenu.stories.js
@@ -23,13 +23,13 @@ export default {
 };
 
 export const Primary = () => ({
-	template: `<div>
+	template: `<div style="padding-left: 80px">
 		<farm-context-menu :items="[{ label: 'Remover', icon: { color: 'error', type: 'open-in-new' } }]" />
 	</div>`,
 });
 
 export const Icons = () => ({
-	template: `<div>
+	template: `<div style="padding-left: 80px">
 		<farm-context-menu
 			ref="icons"
 			:items="[{ label: 'Remover', icon: { color: 'error', type: 'delete' } }]"
@@ -47,7 +47,7 @@ export const Multi = () => ({
 			],
 		};
 	},
-	template: `<div>
+	template: `<div style="padding-left: 80px">
 		<farm-context-menu ref="multi" :items="items" />
 	</div>`,
 });

--- a/src/components/TableContextMenu/TableContextMenu.vue
+++ b/src/components/TableContextMenu/TableContextMenu.vue
@@ -1,37 +1,42 @@
 <template>
-	<v-menu>
-		<template v-slot:activator="{ on, attrs }">
-			<farm-btn icon v-bind="attrs" v-on="on" title="Abrir opções" color="secondary">
+	<farm-contextmenu v-model="value">
+		<template v-slot:activator="{}">
+			<farm-btn icon @click="toggleValue" title="Abrir opções" color="secondary">
 				<farm-icon size="md">dots-horizontal</farm-icon>
 			</farm-btn>
 		</template>
 
-		<v-list dense class="pa-0">
-			<v-list-item
-				v-for="item in items"
-				:key="item.label"
-				:title="item.label"
-				@click="onClick(item.handler)"
-			>
-				<v-list-item-content>
-					<v-list-item-title>
-						<farm-icon
-							v-if="item.icon"
-							size="md"
-							:color="item.icon.color || 'secondary'"
-						>
-							{{ item.icon.type }}
-						</farm-icon>
-						{{ item.label }}
-					</v-list-item-title>
-				</v-list-item-content>
-			</v-list-item>
-		</v-list>
-	</v-menu>
+		<div data-app="true" class="v-application v-application--is-ltr theme--light">
+			<div class="v-application--wrap">
+				<v-list dense class="pa-0">
+					<v-list-item
+						v-for="item in items"
+						:key="item.label"
+						:title="item.label"
+						@click="onClick(item.handler)"
+					>
+						<v-list-item-content>
+							<v-list-item-title>
+								<farm-icon
+									v-if="item.icon"
+									size="md"
+									:color="item.icon.color || 'secondary'"
+								>
+									{{ item.icon.type }}
+								</farm-icon>
+								<farm-caption tag="span" bold>
+									{{ item.label }}
+								</farm-caption>
+							</v-list-item-title>
+						</v-list-item-content>
+					</v-list-item>
+				</v-list>
+			</div>
+		</div>
+	</farm-contextmenu>
 </template>
 <script lang="ts">
 import Vue from 'vue';
-import { VMenu } from 'vuetify/lib/components/VMenu';
 import { VList } from 'vuetify/lib/components/VList';
 import VListItem from 'vuetify/lib/components/VList/VListItem';
 import { VListItemContent, VListItemTitle } from 'vuetify/lib';
@@ -39,7 +44,6 @@ import { VListItemContent, VListItemTitle } from 'vuetify/lib';
 export default Vue.extend({
 	name: 'farm-context-menu',
 	components: {
-		VMenu,
 		VList,
 		VListItem,
 		VListItemContent,
@@ -51,11 +55,19 @@ export default Vue.extend({
 			required: true,
 		},
 	},
+	data() {
+		return {
+			value: false,
+		};
+	},
 	methods: {
 		onClick(handler) {
 			if (handler !== undefined) {
 				this.$emit(handler);
 			}
+		},
+		toggleValue() {
+			this.value = !this.value;
 		},
 	},
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,6 +62,7 @@ export * from './components/Buttons/MultiImportButton';
 export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/Chip';
+export * from './components/ContextMenu';
 export * from './components/CopyToClipboard';
 export * from './components/Logos/ProductLogo';
 export * from './components/Logos/OriginatorLogo';


### PR DESCRIPTION
Essa implementação tem a criação de um componente análogo ao v-menu, chamado farm-contextmenu

<img width="146" alt="image" src="https://user-images.githubusercontent.com/84783765/194063416-873e028f-3e98-43ff-8ed1-ac9781c51876.png">

<img width="172" alt="image" src="https://user-images.githubusercontent.com/84783765/194063361-e82c9c50-ca4c-4279-9762-7a20ec3d1eb9.png">

juntamente com a aplicação dele no TableContextMenu.

<img width="401" alt="image" src="https://user-images.githubusercontent.com/84783765/194063509-2a1abc86-0d51-46f0-9034-dd04c161d7b6.png">

No .scss do ContextMenu tive que deixar fixa a fonte, pq o bootstrap do Vuetify é quem coloca o font-family.
Por isso também no TableContextMenu tem o bootstrap do Vuetify, pra poder vir os estilos do v-list.
A STOR-148 vai tratar de tirar o v-list, então isso vai morrer depois.
