### PR TITLE
fix: tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -4,14 +4,18 @@
 .farm-tooltip {
 	display: inline-block;
 	position: relative;
+}
+
+.farm-tooltip__popup {
+	background-color: themeColor('primary');
 
 	@each $color in $colors {
 		@each $color in $theme-colors-list {
-	
-			&--#{$color} {
-				.farm-tooltip__popup {
-					background-color: themeColor($color);
-				}
+
+			&.farm-tooltip--#{$color} {
+
+				background-color: themeColor($color);
+
 			}
 		}
 	}
@@ -27,8 +31,11 @@
 	padding: 8px 12px;
 	position: absolute;
 	width: 160px;
-	left: 50%;
-	transform: translate(-50%, -110%);
+	background-color: themeColor('primary');
+	contain: content;
+
+	display: block;
+	font-family: 'Montserrat', sans-serif !important;
 
 	&--visible {
 		opacity: 1;

--- a/src/components/Tooltip/Tooltip.stories.js
+++ b/src/components/Tooltip/Tooltip.stories.js
@@ -37,7 +37,9 @@ export const Tooltips = () => ({
             :color="color"
             style="margin-right: 4px"
         >
-            this is the tooltip for {{ color }}
+            <span>
+			this is the tooltip for {{ color }}
+			</span>
             <template v-slot:activator="{ on, attrs }">
                 {{ color }}
             </template>
@@ -81,5 +83,18 @@ export const Visibility = () => ({
 			</v-btn>
             </template>
         </farm-tooltip>
+	</div>`,
+});
+
+export const TooltipTest = () => ({
+	template: `<div style="padding-left: 80px; padding-top: 80px;">
+        <farm-card style="padding: 32px">
+			<farm-tooltip>
+				this is the tooltip!
+				<template v-slot:activator="{ on, attrs }">
+					<farm-btn style="height: 80px">try me</farm-btn>
+				</template>
+			</farm-tooltip>
+		</farm-card>
 	</div>`,
 });

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -86,7 +86,7 @@ export default Vue.extend({
 					window.scrollY -
 					(popupBoundingClientRect.height + 8) +
 					'px';
-				//
+				
 				hasBeenBoostrapped = true;
 			}
 		};


### PR DESCRIPTION
Esse PR corrige o problema do popup do tooltip desaparecer por conta do container pai e como o CSS trabalha com o posicionamento de elementos relatives.
Para contornar, tem que jogar o popup para ser um DOM Node do body.