### PR TITLE
feat: default cols prop (same vuetify API) STOR-189

### DIFF
--- a/src/components/layout/Col/Col.scss
+++ b/src/components/layout/Col/Col.scss
@@ -6,6 +6,7 @@
     flex-basis: 0;
     flex-grow: 1;
     max-width: 100%;
+    width: 100;
 
     &--no-gutters {
         padding: 0;
@@ -13,8 +14,15 @@
 
     @each $k in $aligns {
         &#{'--align-' + $k} {
-            align-self: $k!important;
+            align-self: $k !important;
         }
+    }
+}
+
+@for $i from 1 through 12 {
+    .farm-col--cols-#{$i * 1} {
+        flex: 0 0 (100/12 * $i)+#{"%"};
+        max-width: (100/12 * $i)+#{"%"};
     }
 }
 

--- a/src/components/layout/Col/Col.stories.js
+++ b/src/components/layout/Col/Col.stories.js
@@ -22,51 +22,64 @@ const style = {
 	backgroundColor: 'var(--farm-extra-1-lighten)',
 };
 
+const items = Array.from(Array(12).keys());
+
 export const Primary = () => ({
 	data() {
 		return {
 			style,
 		};
 	},
-	template: '<farm-col :style="style">col</farm-col>',
+	template: `<farm-col>
+	<farm-col :style="style">col</farm-col>
+	</farm-col>`,
 });
+
+export const Cols = () => ({
+	data() {
+		return {
+			style,
+			items
+		};
+	},
+	template: `<farm-row>
+				<farm-col v-for="item in items" :key="'col_' + item" :cols="item + 1" :style="style">{{item + 1}}</farm-col>
+			</farm-row>`,
+});
+
 export const Xl = () => ({
 	data() {
 		return {
 			style,
+			items
 		};
 	},
 	template: `<farm-row>
-				<farm-col xl="4" :style="style">4</farm-col>
-				<farm-col xl="6" :style="style">6</farm-col>
-				<farm-col xl="12" :style="style">12</farm-col>
-				<farm-col xl="2" :style="style">2</farm-col>
-			</farm-row>`,
+			<farm-col v-for="item in items" :key="'xl_' + item" :xl="item + 1" :style="style">{{item + 1}}</farm-col>
+		</farm-row>`,
 });
+
 export const Lg = () => ({
 	data() {
 		return {
 			style,
+			items
 		};
 	},
 	template: `<farm-row>
-		<farm-col lg="4" :style="style">4</farm-col>
-		<farm-col lg="6" :style="style">6</farm-col>
-		<farm-col lg="12" :style="style">12</farm-col>
-		<farm-col lg="2" :style="style">2</farm-col>
-	</farm-row>`,
+			<farm-col v-for="item in items" :key="'lg_' + item" :lg="item + 1" :style="style">{{item + 1}}</farm-col>
+		</farm-row>`,
 });
+
 export const Md = () => ({
 	data() {
 		return {
 			style,
+			items
 		};
 	},
 	template: `<farm-row>
-		<farm-col md="4" :style="style">4</farm-col>
-		<farm-col md="6" :style="style">6</farm-col>
-		<farm-col md="12" :style="style">12</farm-col>
-		<farm-col md="2" :style="style">2</farm-col>
+			<farm-col v-for="item in items" :key="'md_' + item" :md="item + 1" :style="style">{{item + 1}}</farm-col>
 		</farm-row>`,
 });
 
@@ -74,13 +87,11 @@ export const Sm = () => ({
 	data() {
 		return {
 			style,
+			items
 		};
 	},
 	template: `<farm-row>
-			<farm-col sm="4" :style="style">4</farm-col>
-			<farm-col sm="6" :style="style">6</farm-col>
-			<farm-col sm="12" :style="style">12</farm-col>
-			<farm-col sm="2" :style="style">2</farm-col>
+			<farm-col v-for="item in items" :key="'sm_' + item" :sm="item + 1" :style="style">{{item + 1}}</farm-col>
 		</farm-row>`,
 });
 
@@ -88,14 +99,12 @@ export const Xs = () => ({
 	data() {
 		return {
 			style,
+			items
 		};
 	},
 	template: `<farm-row>
-		<farm-col xs="4" :style="style">4</farm-col>
-		<farm-col xs="6" :style="style">6</farm-col>
-		<farm-col xs="12" :style="style">12</farm-col>
-		<farm-col xs="2" :style="style">2</farm-col>
-	</farm-row>`,
+			<farm-col v-for="item in items" :key="'xs_' + item" :xs="item + 1" :style="style">{{item + 1}}</farm-col>
+		</farm-row>`,
 });
 
 export const Combination = () => ({
@@ -105,7 +114,7 @@ export const Combination = () => ({
 		};
 	},
 	template: `<div>
-		<farm-col lg="5" md="4" sm="3" :style="style">lg: 5 - md: 4 - sm: 3</farm-col>
+		<farm-col cols="9" lg="5" md="4" sm="3" :style="style">lg: 5 - md: 4 - sm: 3</farm-col>
 	</div>`,
 });
 export const TagP = () => ({

--- a/src/components/layout/Col/Col.vue
+++ b/src/components/layout/Col/Col.vue
@@ -9,6 +9,7 @@
 			[`farm-col--md-${md}`]: md,
 			[`farm-col--sm-${sm}`]: sm,
 			[`farm-col--xs-${xs}`]: xs,
+			[`farm-col--cols-${cols}`]: cols,
 			'farm-col--no-gutters': noGutters,
 		}"
 	>
@@ -25,6 +26,13 @@ export default Vue.extend({
 		 * Html tag
 		 */
 		tag: { type: String, default: 'div' },
+		/**
+		 * Sets the default number of columns the component extends
+		 */
+		 cols: {
+			type: [String, Number] as PropType<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>,
+			default: null,
+		},
 		/**
 		 * Extra-large breakpoint
 		 */


### PR DESCRIPTION
Adicionada a prop cols para manter a compatibilidade com a API do vuetify: é a quantidade de colunas padrão, para quando não se define as de cada breakpoint.
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/84783765/196146333-29596430-9f34-4bac-bdcf-aec33f1aec78.png">


Com isso será possível fazer um "replace all" em tudo, mas a indicação é irmos migrando aos poucos as telas.