### PR TITLE
fix: copy to clipboard default success message

### DIFF
--- a/src/components/CopyToClipboard/CopyToClipboard.stories.js
+++ b/src/components/CopyToClipboard/CopyToClipboard.stories.js
@@ -9,7 +9,8 @@ export default {
 		docs: {
 			description: {
 				component: `CopyToClipboard<br />
-				selector: <em>farm-copytobclipboard</em>
+				selector: <em>farm-copytobclipboard</em><br />
+				<span style="color: var(--farm-primary-base);">ready for use</span>
 				`,
 			},
 		},
@@ -28,5 +29,12 @@ export const NoIcon = () => ({
 	components: { 'farm-copytoclipboard': CopyToClipboard },
 	template: `<div style="max-width: 480px; padding-top: 80px; padding-left: 80px;">
 		<farm-copytoclipboard toCopy="To be copied" :isIcon="false" />
+    </div>`,
+});
+
+export const CustomSuccessMessage = () => ({
+	components: { 'farm-copytoclipboard': CopyToClipboard },
+	template: `<div style="max-width: 480px; padding-top: 80px; padding-left: 80px;">
+		<farm-copytoclipboard toCopy="To be copied" success-message="Custom Succes Message" />
     </div>`,
 });

--- a/src/components/CopyToClipboard/CopyToClipboard.vue
+++ b/src/components/CopyToClipboard/CopyToClipboard.vue
@@ -28,9 +28,12 @@ export default Vue.extend({
 		 * Is button with icon?
 		 */
 		isIcon: { type: Boolean, default: true },
+		/**
+		 * Success message content after copy
+		 */
 		successMessage: {
 			type: String,
-			default: 'Conteúdo copiado para a área de trabalhado',
+			default: 'Conteúdo copiado para a área de trabalho',
 		},
 	},
 	setup(props) {
@@ -52,7 +55,7 @@ export default Vue.extend({
 			setTimeout(() => {
 				show.value = false;
 				disabled.value = false;
-			}, 1000);
+			}, 2000);
 		};
 
 		return {

--- a/src/components/CopyToClipboard/CopyToClipboard.vue
+++ b/src/components/CopyToClipboard/CopyToClipboard.vue
@@ -28,18 +28,22 @@ export default Vue.extend({
 		 * Is button with icon?
 		 */
 		isIcon: { type: Boolean, default: true },
+		successMessage: {
+			type: String,
+			default: 'Conteúdo copiado para a área de trabalhado',
+		},
 	},
 	setup(props) {
 		const show = ref(false);
 		const feedbackMessage = ref('');
 		const disabled = ref(false);
-		const { toCopy, isIcon } = toRefs(props);
+		const { toCopy, isIcon, successMessage } = toRefs(props);
 
 		const onClick = async () => {
 			disabled.value = true;
 			try {
 				await toClipboard(toCopy.value);
-				feedbackMessage.value = 'Conteúdo copiado para a área de trabalhado';
+				feedbackMessage.value = successMessage.value;
 			} catch (e) {
 				feedbackMessage.value = 'Ocorreu um erro: ' + e;
 			}


### PR DESCRIPTION
Fix default success message
<img width="363" alt="image" src="https://user-images.githubusercontent.com/84783765/198058572-03034f18-e280-4162-b53f-8cddec77a65e.png">

and add prop do customize it:
<img width="296" alt="image" src="https://user-images.githubusercontent.com/84783765/198058777-6e64e316-1014-43b0-b3fc-37382e1f09c4.png">
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/84783765/198059201-494aaf18-e1f0-44ad-a0e9-80fed91f7ccf.png">
