### PR TITLE
feat: better css and example for deprecated textfield STOR-76-77-187

### DIFF
--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -1,4 +1,5 @@
 .farm-textfield {
+    padding-bottom: 4px;
 
     &.v-input {
 
@@ -8,20 +9,20 @@
                 min-height: 36px !important;
                 height: 36px;
                 background: white;
+                padding: 0 8px;
 
                 fieldset {
-                    border-color: var(--v-gray-lighten2);
+                    border-color: var(--farm-gray-lighten);
                 }
 
                 input,
                 .v-select__selection {
-                    font-size: 0.75rem;
+                    font-size: 12px;
                 }
             }
 
-            &.v-input--is-label-active.v-input--is-focused {
+            &.v-input--is-label-active.v-input--is-focused:not(.error--text) {
                 :deep(.v-input__slot fieldset) {
-
                     border-color: var(--v-secondary-base);
                 }
 
@@ -32,20 +33,11 @@
 
             &.error--text {
                 :deep(.v-input__slot) fieldset {
-                    border-color: var(--v-error-base);
+                    border-color: var(--farm-error-primary);
                     border-width: 1px;
                 }
 
-                &:after {
-                    content: '\F0028';
-                    position: absolute;
-                    font: normal normal normal 24px/1 'Material Design Icons';
-                    right: 6px;
-                    top: 6px;
-                }
             }
         }
     }
 }
-
-

--- a/src/components/TextField/TextField.stories.js
+++ b/src/components/TextField/TextField.stories.js
@@ -9,7 +9,8 @@ export default {
 		docs: {
 			description: {
 				component: `Text field<br />
-				selector: <em>farm-texfield</em>
+				selector: <em>farm-texfield</em><br />
+				<span style="color: var(--farm-primary-base);">ready for use</span>
 				`,
 			},
 		},
@@ -24,12 +25,34 @@ export default {
 export const Primary = () => ({
 	data() {
 		return {
-			v: '',
+			v: 'input text',
 		};
 	},
 	template: `<div style="width: 480px">
 		<farm-textfield v-model="v" />
 		value: {{ v }}
+	</div>`,
+});
+
+export const Disabled = () => ({
+	data() {
+		return {
+			v: 'disabled field',
+		};
+	},
+	template: `<div style="width: 480px">
+		<farm-textfield v-model="v" disabled />
+	</div>`,
+});
+
+export const Readonly = () => ({
+	data() {
+		return {
+			v: 'readonly field',
+		};
+	},
+	template: `<div style="width: 480px">
+		<farm-textfield v-model="v" readonly />
 	</div>`,
 });
 
@@ -45,18 +68,37 @@ export const BindVar = () => ({
 	</div>`,
 });
 
-export const Rules = () => ({
+export const Validate = () => ({
 	data() {
 		return {
-			v: '',
+			v1: 'input 1',
+			v2: '',
+			v3: '',
+			v4: '',
 			rules: {
-				required: val => !!val,
+				required: value => !!value || 'Required field',
+				email: v =>
+					!v ||
+					/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(v) ||
+					'Must be an e-mail',
 			},
 		};
 	},
 	template: `<div style="width: 480px">
-		<h4>Custom rule (required field)</h4>
-		<farm-textfield v-model="v" :rules="[rules.required]" />
-		value: {{ v }}
+		<farm-label required>Required field</farm-label>
+		<farm-textfield v-model="v1" :rules="[rules.required]" />
+
+		<farm-label>E-mail</farm-label>
+		<farm-textfield v-model="v2" :rules="[rules.email]" />
+
+		<farm-label required>Required and e-mail</farm-label>
+		<farm-textfield v-model="v3" :rules="[rules.required, rules.email]" />
+
+		<farm-label required>Required field with hint</farm-label>
+		<farm-textfield v-model="v4" :rules="[rules.required]" hint="hint text" />
+
+		<farm-label required>Required field with icon</farm-label>
+		<farm-textfield v-model="v1" :rules="[rules.required]" append-icon="mdi-eye" />
+
 	</div>`,
 });


### PR DESCRIPTION
- scss using farm palette
- adjust layout using DS definition
<img width="518" alt="Captura de Tela 2022-11-09 às 17 09 18" src="https://user-images.githubusercontent.com/84783765/200897040-59533582-f7ed-4e83-8680-0f0eb9672086.png">
<img width="514" alt="image" src="https://user-images.githubusercontent.com/84783765/200897118-a68ae331-ca8f-4ee8-bd84-3b1b5c3b93ea.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/84783765/200897185-277ba092-5df4-4aea-b492-7defe483a3c0.png">

- disabled documentation
<img width="1038" alt="Captura de Tela 2022-11-09 às 16 54 21" src="https://user-images.githubusercontent.com/84783765/200896382-a2fecffc-15f4-4462-bef3-9721ad4ed3fd.png">
- error state fix (do not show icon)

