### PR TITLE
feat: make form fields pristine when form validation restarts

### DIFF
--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -158,6 +158,10 @@ export default Vue.extend({
 
 		let validate = validateFormMethodBuilder(errorBucket, valid, fieldValidator);
 
+		const makePristine = () => {
+			isTouched.value = false;
+		};
+
 		return {
 			innerValue,
 			label,
@@ -171,6 +175,8 @@ export default Vue.extend({
 			reset,
 			validate,
 			showError,
+			makePristine,
+			isTouched,
 		};
 	},
 });

--- a/src/components/Checkbox/__tests__/Checkbox.spec.js
+++ b/src/components/Checkbox/__tests__/Checkbox.spec.js
@@ -3,6 +3,7 @@ import Checkbox from '../Checkbox';
 
 describe('Checkbox component', () => {
 	let wrapper;
+	let component;
 
 	beforeEach(() => {
 		wrapper = shallowMount(Checkbox, {
@@ -10,6 +11,7 @@ describe('Checkbox component', () => {
 				value: false,
 			},
 		});
+		component = wrapper.vm;
 	});
 
 	test('Created hook', () => {
@@ -19,6 +21,14 @@ describe('Checkbox component', () => {
 	describe('mount component', () => {
 		it('renders correctly', () => {
 			expect(wrapper.element).toMatchSnapshot();
+		});
+	});
+
+	describe('methods', () => {
+		it('makePristine', () => {
+			component.isTouched = true;
+			component.makePristine();
+			expect(component.isTouched).toBeFalsy();
 		});
 	});
 });

--- a/src/components/Form/Form.stories.js
+++ b/src/components/Form/Form.stories.js
@@ -333,3 +333,55 @@ export const ValidateRadioGroup = () => ({
         </farm-form>
     `,
 });
+
+export const RestartValidation = () => ({
+	data() {
+		return {
+			form: {
+				document: null,
+				name: null,
+				checkbox: null,
+				birthDate: '',
+				selectId: null,
+				rangeDate: [],
+			},
+			validForm: true,
+			rules: {
+				required: value => !!value || 'Campo obrigatório',
+				checked: value => !!value || 'Deve estar marcado',
+			},
+			items: [
+				{ value: null, text: '' },
+				{ value: 1, text: 'label 1' },
+				{ value: 2, text: 'label 2' },
+			],
+			styles,
+		};
+	},
+	template: `
+        <farm-form v-model="validForm" :style="[styles.vForm]" ref="form">
+			{{ validForm }}
+
+			<farm-label :required="true">Nome</farm-label>
+			<farm-textfield-v2 v-model="form.name" :rules="[rules.required]" />
+			
+			<div>
+				<farm-label :required="true">Documento</farm-label>
+				<farm-textfield-v2 v-model="form.document" :rules="[rules.required]" />
+			</div>
+		
+			
+			<farm-label :required="true">True/false</farm-label>
+			<farm-checkbox v-model="form.checkbox" value="1" :rules="[rules.checked]" />
+			
+			<farm-label :required="true">Select</farm-label>
+			<farm-select :rules="[rules.required]" :items="items" v-model="form.selectId"/>
+			
+            <div class="footer" :style="[styles.footer]">
+			<farm-btn outlined @click="$refs.form.restartValidation()" class="mr-3">Restart Validation</farm-btn>
+				<farm-btn outlined @click="$refs.form.reset()" class="mr-3">Reset</farm-btn>
+				<farm-btn :disabled="!validForm">Salvar</farm-btn>
+            </div>
+        </farm-form>
+    `,
+});

--- a/src/components/Form/Form.vue
+++ b/src/components/Form/Form.vue
@@ -72,6 +72,7 @@ export default Vue.extend({
 			validationFields.forEach(field => {
 				watchInput(field);
 				field.validate(field.value);
+				if (field.makePristine) field.makePristine();
 			});
 		};
 

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -218,6 +218,10 @@ export default Vue.extend({
 			emit('click');
 		};
 
+		const makePristine = () => {
+			isTouched.value = false;
+		};
+
 		const updateSelectedTextValue = () => {
 			if (!items.value || items.value.length === 0 || !innerValue.value) {
 				selectedText.value = '';
@@ -250,6 +254,7 @@ export default Vue.extend({
 			onBlur,
 			clickInput,
 			updateSelectedTextValue,
+			makePristine,
 		};
 	},
 });

--- a/src/components/Select/__tests__/Select.spec.js
+++ b/src/components/Select/__tests__/Select.spec.js
@@ -41,5 +41,11 @@ describe('Select component', () => {
 			component.updateSelectedTextValue();
 			expect(component.selectedText).toBeDefined();
 		});
+
+		it('makePristine', () => {
+			component.isTouched = true;
+			component.makePristine();
+			expect(component.isTouched).toBeFalsy();
+		});
 	});
 });

--- a/src/components/TextFieldV2/TextFieldV2.vue
+++ b/src/components/TextFieldV2/TextFieldV2.vue
@@ -176,6 +176,11 @@ export default Vue.extend({
 			emit('input', innerValue.value);
 		};
 
+		const makePristine = () => {
+			isTouched.value = false;
+			isBlured.value = false;
+		};
+
 		return {
 			innerValue,
 			errorBucket,
@@ -189,6 +194,7 @@ export default Vue.extend({
 			onKeyUp,
 			onBlur,
 			reset,
+			makePristine,
 		};
 	},
 });

--- a/src/components/TextFieldV2/__tests__/TextFieldV2.spec.js
+++ b/src/components/TextFieldV2/__tests__/TextFieldV2.spec.js
@@ -37,5 +37,12 @@ describe('TextFieldV2 component', () => {
 			expect(component.isBlured).toBeTruthy();
 		});
 
+		it('makePristine', () => {
+			component.isTouched = true;
+			component.isBlured = true;
+			component.makePristine();
+			expect(component.isTouched).toBeFalsy();
+			expect(component.isBlured).toBeFalsy();
+		});
 	});
 });


### PR DESCRIPTION
When form validation restarts

<img width="647" alt="image" src="https://user-images.githubusercontent.com/84783765/203967872-85eb0140-bb46-413c-aa33-f1158044da32.png">

the form fields return to a pristine state
<img width="580" alt="image" src="https://user-images.githubusercontent.com/84783765/203967934-46c25393-69a5-471a-bfd0-80c6f96487da.png">

The previous behavior to reset is the same, fields are still marked as touched and if they are invalid, proper UI and messages are shown
<img width="535" alt="image" src="https://user-images.githubusercontent.com/84783765/203968162-dac09e6f-90ab-4f9d-9667-7e0f757e8af7.png">
  