### PR TITLE
fix: contextmenu position set to 0 when closes

### DIFF
--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -86,6 +86,9 @@ export default Vue.extend({
 					window.addEventListener('resize', resizeWindowHandler);
 					calculatePosition();
 				} else {
+					styles.top = 0;
+					styles.left = 0;
+					styles.zIndex = 0;
 					window.removeEventListener('click', outClick);
 				}
 			}
@@ -113,7 +116,7 @@ export default Vue.extend({
 					? parseInt(activatorBoundingClientRect.width)
 					: 96) + 'px';
 
-			if(activatorBoundingClientRect.width < 96) {
+			if (activatorBoundingClientRect.width < 96) {
 				const w = popupClientRect.width < 96 ? 96 : popupClientRect.width;
 				offsetLeft =
 					activatorBoundingClientRect.left +


### PR DESCRIPTION
When context menu is closed, the calculated top and left position were not being reseted. In some scenarios it added an extra scroll to the page due to it absolute positioning:

![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/84783765/206709896-5c67356e-8fe6-4a07-a720-04ed1426d40c.png)
