### PR TITLE
feat: STOR-348

### DIFF
--- a/src/components/IdCaption/IdCaption.scss
+++ b/src/components/IdCaption/IdCaption.scss
@@ -1,8 +1,14 @@
 .idcaption {
 	display: flex;
 	min-height: 48px;
+	max-width: 100%;
+
 	.farm-icon-box {
 		margin-right: 8px;
+	}
+
+	&.farm-idcaption--noicon .idcaption__body {
+		max-width: 100%;
 	}
 
 	&__body {
@@ -11,6 +17,7 @@
 		flex-direction: column;
 		justify-content: space-between;
 		align-content: flex-start;
+		max-width: calc(100% - 48px);
 
 		&--single {
 			justify-content: center;
@@ -21,22 +28,21 @@
 			margin-bottom: 0;
 			display: flex;
 			flex: none;
+			position: relative;
+			align-items: center;
+			height: 18px;
 
 			>span {
-				position: relative;
+				max-width: 100%;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
 			}
 		}
 
-		.farm-btn,
 		.farm-tooltip {
-			position: absolute;
-			right: -30px;
-			top: -8px;
+			padding-right: 1px;
 		}
 	}
 
-	.farm-btn--clickable {
-		position: absolute;
-		top: -50%;
-	}
 }

--- a/src/components/IdCaption/IdCaption.stories.js
+++ b/src/components/IdCaption/IdCaption.stories.js
@@ -23,11 +23,17 @@ export default {
 };
 
 export const Primary = () => ({
+    methods: {
+        onLinkClick() {
+            alert('onLinkClick');
+        }
+    },
 	template: `
     <farm-idcaption 
     icon="account-box-outline"
     copyText="texto a copiar"
     :link="true"
+    @onLinkClick="onLinkClick"
     >
         <template v-slot:title>
             Upper Line Text
@@ -77,7 +83,6 @@ export const NoUpperText = () => ({
     <farm-idcaption 
     icon="account-box-outline"
     copyText="texto a copiar"
-    :link="true"
     >
         <template v-slot:subtitle>
             Lower:Line Text
@@ -90,7 +95,6 @@ export const NoBottomText = () => ({
 	template: `
     <farm-idcaption 
     icon="account-box-outline" 
-    copyText="texto a copiar"
     :link="true"
     >
         <template v-slot:title>
@@ -100,10 +104,11 @@ export const NoBottomText = () => ({
     `,
 });
 
-export const NoTextToClip = () => ({
+export const NoTextToCopy = () => ({
 	template: `
     <farm-idcaption 
-    icon="account-box-outline" 
+    icon="account-box-outline"
+    copyText=""
     :link="true"
     >
         <template v-slot:title>
@@ -185,20 +190,20 @@ export const CustomTooltipColor = () => ({
     `,
 });
 
-
-export const Teste = () => ({
+export const LongTitles = () => ({
 	template: `
+    <farm-col sm="3">
     <farm-idcaption 
     icon="account-box-outline"
-    copy-text=""
+    copyText="texto a copiar"
     :link="true"
     >
         <template v-slot:title>
-            Upper Line Text
+            Upper Line Text Upper Line Text
         </template>
         <template v-slot:subtitle>
-            0
+            Lower: Line Text Line Text Line Text Line
         </template>
     </farm-idcaption>
-    `,
+    </farm-col>`,
 });

--- a/src/components/IdCaption/IdCaption.vue
+++ b/src/components/IdCaption/IdCaption.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="idcaption farm-idcaption">
+	<div :class="{ idcaption: true, 'farm-idcaption': true, 'farm-idcaption--noicon': !icon }">
 		<farm-icon-box v-if="icon" :icon="icon" :color="iconBoxColor" size="md" />
 		<div
 			:class="{ idcaption__body: true, 'idcaption__body--single': !hasTitle || !hasSubtitle }"
@@ -7,28 +7,28 @@
 			<farm-caption variation="medium" v-if="hasTitle">
 				<span>
 					<slot name="title"></slot>
-					<farm-btn
-						v-if="link"
-						icon
-						color="primary"
-						class="farm-btn--clickable"
-						@click="$emit('onLinkClick')"
-					>
-						<farm-icon size="xs">open-in-new</farm-icon>
-					</farm-btn>
 				</span>
+				<farm-btn
+					v-if="link"
+					icon
+					color="primary"
+					class="farm-btn--clickable"
+					@click="$emit('onLinkClick')"
+				>
+					<farm-icon size="xs">open-in-new</farm-icon>
+				</farm-btn>
 			</farm-caption>
 
 			<farm-caption variation="regular" color="gray" v-if="hasSubtitle">
 				<span>
 					<slot name="subtitle"></slot>
-					<farm-copytoclipboard
-						v-if="copyText"
-						:toCopy="copyText"
-						:successMessage="successMessage"
-						:tooltipColor="tooltipColor"
-					/>
 				</span>
+				<farm-copytoclipboard
+					v-if="copyText"
+					:toCopy="copyText"
+					:successMessage="successMessage"
+					:tooltipColor="tooltipColor"
+				/>
 			</farm-caption>
 		</div>
 	</div>


### PR DESCRIPTION
Text ellipsis to IdCaption titles:

![image](https://user-images.githubusercontent.com/84783765/210578055-32b48122-61c7-44c9-b6b0-a01b0ff94a90.png)

To achieve this UI, the component has been refactored; the action buttons/icons does not have absolute position and the component itself and the farm-typography elements must have max-width.