### PR TITLE
fix: STOR-356

### DIFF
--- a/src/components/Chip/Chip.stories.js
+++ b/src/components/Chip/Chip.stories.js
@@ -88,3 +88,9 @@ export const CustomTypography = () => ({
 		</farm-chip>
 	</div>`,
 });
+
+export const Ellipsis = () => ({
+	template: `<div style="width: 100px;">
+		<farm-chip color="primary">Very long text here</farm-chip>
+	</div>`,
+});

--- a/src/components/Chip/Chip.vue
+++ b/src/components/Chip/Chip.vue
@@ -8,7 +8,7 @@
 			'farm-chip--darken': variation === 'darken',
 		}"
 	>
-		<farm-typography tag="span" size="sm" color="white"> <slot></slot> </farm-typography>
+		<farm-typography tag="span" size="sm" color="white" ellipsis> <slot></slot> </farm-typography>
 	</span>
 </template>
 <script lang="ts">

--- a/src/components/DialogHeader/DialogHeader.scss
+++ b/src/components/DialogHeader/DialogHeader.scss
@@ -1,3 +1,5 @@
+@import '../../configurations/mixins';
+
 .farm-dialog-header__close {
 	position: absolute;
 	margin-top: 0;
@@ -26,8 +28,6 @@ header {
 		align-items: center;
 		width: 100%;
 		margin-bottom: 0;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		@include ellipsis;
 	}
 }

--- a/src/components/IdCaption/IdCaption.scss
+++ b/src/components/IdCaption/IdCaption.scss
@@ -1,3 +1,5 @@
+@import '../../configurations/mixins';
+
 .idcaption {
 	display: flex;
 	min-height: 48px;
@@ -34,9 +36,7 @@
 
 			>span {
 				max-width: 100%;
-				white-space: nowrap;
-				overflow: hidden;
-				text-overflow: ellipsis;
+				@include ellipsis;
 			}
 		}
 

--- a/src/components/Typography/Typography.scss
+++ b/src/components/Typography/Typography.scss
@@ -4,6 +4,7 @@
 
 .farm-typography {
 	font-size: 16px;
+	color: var(--farm-text-primary);
 
 	&[bold] {
 		font-weight: bold;
@@ -25,16 +26,12 @@
 		margin-bottom: auto;
 	}
 
-	color: var(--farm-text-primary);
-
 	&--lighten {
 		color: var(--farm-text-secondary);
 	}
 
 	&.farm-typography--ellipsis {
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
+		@include ellipsis;
 	}
 
 	@each $k in $theme-colors-list {

--- a/src/configurations/_mixins.scss
+++ b/src/configurations/_mixins.scss
@@ -76,10 +76,17 @@
         }
     }
 }
+
 @mixin activateRipple {
     &:hover {
         .farm-ripple:before {
             opacity: 0.3;
         }
     }
+}
+
+@mixin ellipsis {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }


### PR DESCRIPTION
Added css ellipsis to farm-chip, so the chip will never break line if the chip is wider than the parent.

![image](https://user-images.githubusercontent.com/84783765/211590085-b2e10cbc-b44a-456b-aaf4-cf5a56be1e46.png)
