### PR TITLE
feat: STOR-305

### DIFF
--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -35,8 +35,12 @@ export const Primary = () => ({
 		};
 	},
 	template: `<div style="width: 120px;">
-		<farm-select v-model="v" :items="items" />
+		<farm-label for="select_id">
+			label
+		</farm-label>
+		<farm-select id="select_id" v-model="v" :items="items" />
 		v-model: {{ v }}
+
 	</div>`,
 });
 

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -1,6 +1,5 @@
 <template>
 	<div
-		class="farm-textfield"
 		:class="{
 			'farm-textfield': true,
 			'farm-textfield--validatable': rules.length > 0,
@@ -11,8 +10,9 @@
 			'farm-textfield--hiddendetails': hideDetails,
 		}"
 		v-if="!readonly && !disabled"
+		:id="customId"
 	>
-		<farm-contextmenu bottom v-model="isVisible" :stay-open="multiple">
+		<farm-contextmenu bottom v-model="isVisible" :stay-open="multiple" ref="contextmenu">
 			<farm-list v-if="!readonly">
 				<farm-listitem
 					v-for="(item, index) in items"
@@ -29,15 +29,15 @@
 						value="1"
 						size="sm"
 						v-if="isChecked(item)"
-					></farm-checkbox>
+					/>
 					<farm-checkbox
 						class="farm-select__checkbox"
 						v-model="checked"
 						value="2"
 						size="sm"
 						v-else-if="multiple"
-					></farm-checkbox
-					><farm-caption bold tag="span">{{ item[itemText] }}</farm-caption>
+					/>
+					<farm-caption bold tag="span">{{ item[itemText] }}</farm-caption>
 				</farm-listitem>
 				<farm-listitem v-if="!items || items.length === 0">
 					{{ noDataText }}
@@ -46,9 +46,9 @@
 			<template v-slot:activator="{}">
 				<div class="farm-textfield--input farm-textfield--input--iconed">
 					<input
+						v-bind="$attrs"
+						:id="$props.id"
 						v-model="selectedText"
-						:disabled="disabled"
-						:readonly="true"
 						@click="clickInput"
 						@keyup="onKeyUp"
 						@blur="onBlur"
@@ -75,6 +75,7 @@ import validateFormStateBuilder from '../../composition/validateFormStateBuilder
 import validateFormFieldBuilder from '../../composition/validateFormFieldBuilder';
 import validateFormMethodBuilder from '../../composition/validateFormMethodBuilder';
 import deepEqual from '../../composition/deepEqual';
+import randomId from '../../helpers/randomId';
 
 export default Vue.extend({
 	name: 'farm-select',
@@ -152,6 +153,13 @@ export default Vue.extend({
 			type: Boolean,
 			default: false,
 		},
+		/**
+		 * Select id
+		 */
+		id: {
+			type: String,
+			default: '',
+		},
 	},
 	setup(props, { emit }) {
 		const { rules, items, itemText, itemValue, disabled, multiple } = toRefs(props);
@@ -172,6 +180,8 @@ export default Vue.extend({
 		const hasError = computed(() => {
 			return errorBucket.value.length > 0;
 		});
+
+		const customId = 'farm-select-' + (props.id || randomId(2));
 
 		const showErrorText = computed(() => hasError.value && isTouched.value);
 
@@ -334,6 +344,7 @@ export default Vue.extend({
 			isTouched,
 			isBlured,
 			isVisible,
+			customId,
 			showErrorText,
 			validate,
 			reset,

--- a/src/components/TextArea/TextArea.vue
+++ b/src/components/TextArea/TextArea.vue
@@ -17,8 +17,9 @@
 			}"
 		>
 			<textarea
-				v-bind="$attrs"
 				v-model="innerValue"
+				v-bind="$attrs"
+				:id="$props.id"
 				:rows="$props.rows"
 				:disabled="disabled"
 				:readonly="readonly"
@@ -42,6 +43,7 @@ import validateFormStateBuilder from '../../composition/validateFormStateBuilder
 import validateFormFieldBuilder from '../../composition/validateFormFieldBuilder';
 import validateFormMethodBuilder from '../../composition/validateFormMethodBuilder';
 import deepEqual from '../../composition/deepEqual';
+import randomId from '../../helpers/randomId';
 
 export default Vue.extend({
 	name: 'farm-textarea',
@@ -95,6 +97,13 @@ export default Vue.extend({
 			type: Boolean,
 			default: false,
 		},
+		/**
+		 * Select id
+		 */
+		id: {
+			type: String,
+			default: '',
+		},
 	},
 	setup(props, { emit }) {
 		const { rules } = toRefs(props);
@@ -109,6 +118,7 @@ export default Vue.extend({
 		const hasError = computed(() => {
 			return errorBucket.value.length > 0;
 		});
+		const customId = 'farm-textarea-' + (props.id || randomId(2));
 
 		const showErrorText = computed(() => hasError.value && isTouched.value);
 
@@ -171,6 +181,7 @@ export default Vue.extend({
 			valid,
 			validatable,
 			hasError,
+			customId,
 			isTouched,
 			isBlured,
 			showErrorText,

--- a/src/components/TextFieldV2/TextFieldV2.stories.js
+++ b/src/components/TextFieldV2/TextFieldV2.stories.js
@@ -39,7 +39,10 @@ export const Primary = () => ({
 		};
 	},
 	template: `<div style="width: 480px;">
-		<farm-textfield-v2 v-model="v" />
+		<farm-label for="select_label">
+			label
+		</farm-label>
+		<farm-textfield-v2 id="select_label" v-model="v" />
 		v-model: {{ v }}
 	</div>`,
 });

--- a/src/components/TextFieldV2/TextFieldV2.vue
+++ b/src/components/TextFieldV2/TextFieldV2.vue
@@ -10,6 +10,7 @@
 			'farm-textfield--disabled': disabled,
 			'farm-textfield--hiddendetails': hideDetails,
 		}"
+		:id="customId"
 	>
 		<div
 			:class="{
@@ -28,6 +29,7 @@
 				v-bind="$attrs"
 				v-model="innerValue"
 				v-mask="mask"
+				:id="$props.id"
 				:disabled="disabled"
 				:readonly="readonly"
 				@click="$emit('click')"
@@ -61,6 +63,7 @@ import validateFormStateBuilder from '../../composition/validateFormStateBuilder
 import validateFormFieldBuilder from '../../composition/validateFormFieldBuilder';
 import validateFormMethodBuilder from '../../composition/validateFormMethodBuilder';
 import deepEqual from '../../composition/deepEqual';
+import randomId from '../../helpers/randomId';
 
 export default Vue.extend({
 	name: 'farm-textfield-v2',
@@ -125,6 +128,13 @@ export default Vue.extend({
 			type: Boolean,
 			default: false,
 		},
+		/**
+		 * Input id
+		 */
+		id: {
+			type: String,
+			default: '',
+		},
 	},
 	setup(props, { emit }) {
 		const { rules } = toRefs(props);
@@ -139,6 +149,7 @@ export default Vue.extend({
 		const hasError = computed(() => {
 			return errorBucket.value.length > 0;
 		});
+		const customId = 'farm-textfield-' + (props.id || randomId(2));
 
 		const showErrorText = computed(() => hasError.value && isTouched.value);
 
@@ -201,6 +212,7 @@ export default Vue.extend({
 			valid,
 			validatable,
 			hasError,
+			customId,
 			isTouched,
 			isBlured,
 			showErrorText,

--- a/src/helpers/randomId.ts
+++ b/src/helpers/randomId.ts
@@ -1,0 +1,9 @@
+export default (length: number) => {
+	let text = '';
+	const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+	for (let i = 0; i < length; i++) {
+		text += possible.charAt(Math.floor(Math.random() * possible.length));
+	}
+	return text;
+};

--- a/tests/unit/helpers/randomId.spec.js
+++ b/tests/unit/helpers/randomId.spec.js
@@ -1,0 +1,21 @@
+import randomId from '@/helpers/randomId';
+
+describe('randomId', () => {
+	it('should return a string of the specified length', () => {
+		const length = 10;
+		const randomString = randomId(length);
+		expect(randomString).toHaveLength(length);
+	});
+
+	it('should only contain alphanumeric characters', () => {
+		const randomString = randomId(10);
+		const pattern = /^[A-Za-z0-9]+$/;
+		expect(randomString).toMatch(pattern);
+	});
+
+	it('should return different strings on every call', () => {
+		const randomString1 = randomId(10);
+		const randomString2 = randomId(10);
+		expect(randomString1).not.toEqual(randomString2);
+	});
+});


### PR DESCRIPTION
In select, textfield and textarea, the id have been defined as a prop and added to form native elements. The parent element has now a custom id, generated on the fly.
With this, when label (or farm-label) has the for attribute set and it matches with the id given for a certain farm form component, it receives focus. 