### PR TITLE
feat: label fix color from palette STOR-432

### DIFF
--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -4,10 +4,11 @@
     font-size: 12px;
     margin-bottom: 8px;
     line-height: 24px;
+    color: var(--farm-text-primary);
 
     &.farm-label--required::after {
         content: '*';
         margin-left: 2px;
-        color: var(--v-error-base);
+        color: var(--farm-error-base);
     }
 }

--- a/src/components/Label/Label.vue
+++ b/src/components/Label/Label.vue
@@ -1,5 +1,9 @@
 <template>
-	<label :class="{ 'farm-label': true, 'farm-label--required': required }" v-bind="$attrs">
+	<label
+		:class="{ 'farm-label': true, 'farm-label--required': required }"
+		v-on="$listeners"
+		v-bind="$attrs"
+	>
 		<slot></slot>
 	</label>
 </template>

--- a/src/components/SelectModalOptions/SelectModalOptions.stories.js
+++ b/src/components/SelectModalOptions/SelectModalOptions.stories.js
@@ -1,7 +1,7 @@
 import SelectModalOptions from './SelectModalOptions';
 
 export default {
-	title: 'INteractions/SelectModalOptions',
+	title: 'Interactions/SelectModalOptions',
 	component: SelectModalOptions,
 };
 


### PR DESCRIPTION
Fix colors in component

![Captura de Tela 2023-02-24 às 13 42 40](https://user-images.githubusercontent.com/84783765/221193672-e42bc2dd-bc6a-470f-8f2c-1d81c120ba41.png)

to avoid errors like this:
![image](https://user-images.githubusercontent.com/84783765/221193823-4a56f89a-0b5a-409c-be33-ac26b243ded0.png)

where the parent component has a different font color and the farm-label inherits it.