### PR TITLE
feat: STOR-447

### DIFF
--- a/src/components/DataTableHeader/DataTableHeader.scss
+++ b/src/components/DataTableHeader/DataTableHeader.scss
@@ -10,6 +10,7 @@
 	}
 
 	.farm-icon {
+		transition: transform .8s ease-in-out;  
 		&.farm-icon--asc {
 			transform: rotateX(180deg);
 		}
@@ -19,13 +20,19 @@
 th.sortable {
 	cursor: pointer;
 
+
 	&:not(.active) {
 		&:hover {
-			.farm-icon {
-				opacity: 0.5 !important;
+			.farm-icon::before {
+				color: var(--farm-gray-base) !important;
 			}
 		}
 	}
+
+	.header-text {
+		transition: color 0.5s ease;
+	}
+
 }
 
 th span.span-checkbox {
@@ -47,7 +54,7 @@ th {
 }
 
 :deep(.mdi-sort-descending)::before {
-	color: var(--farm-gray-base);
+	color: var(--farm-secondary-base);
 	font-size: 12px;
 	font-weight: 900;
 }

--- a/src/components/DataTableHeader/DataTableHeader.stories.js
+++ b/src/components/DataTableHeader/DataTableHeader.stories.js
@@ -90,13 +90,14 @@ const headers = [
 		sortable: true,
 		value: 'name',
 		align: 'left',
+		width: 120,
 	},
 	{
 		text: 'Aprovado',
 		sortable: true,
 		value: 'approvedAmount',
 		align: 'center',
-		width: 320,
+		width: 160,
 	},
 	{
 		text: 'Disponível',

--- a/src/components/DataTableHeader/DataTableHeader.vue
+++ b/src/components/DataTableHeader/DataTableHeader.vue
@@ -118,10 +118,13 @@ export default Vue.extend({
 			return value ? 'DESC' : 'ASC';
 		},
 		clickSort(value, index) {
+			const isClicked = this.sortClick[index].clicked;
 			this.removeClicked();
 			this.sortClick[index].clicked = true;
 			this.sortClick[index].show = true;
-			this.sortClick[index][value] = !this.sortClick[index][value];
+			if (isClicked) {
+				this.sortClick[index][value] = !this.sortClick[index][value];
+			}
 			this.sortClick[index].descending = this.getTypeSort(this.sortClick[index][value]);
 			this.$emit('onClickSort', this.sortClick[index]);
 		},
@@ -167,7 +170,10 @@ export default Vue.extend({
 	created() {
 		for (let i = 0; i < this.headers.length; i += 1) {
 			this.sortClick.push({
-				[this.headers[i].value]: this.firstSelected && i === this.selectedIndex && this.headers[i].order === 'DESC',
+				[this.headers[i].value]:
+					this.firstSelected &&
+					i === this.selectedIndex &&
+					this.headers[i].order === 'DESC',
 				descending: this.headers[i].order || 'ASC',
 				field: this.headers[i].value,
 				clicked: this.checkFirstSelected(i),


### PR DESCRIPTION
In DataTableHeader, when user clicks on a cell that is not active to sort the previous behaviour was that it toggled the last value. Now, it does not toggle, so the user will the icon in its inactive state (example: ASC) and when the cell is clicked the icon goes to the active state (darker color) but does not toggle.
The previous behaviour could confuse the user.
Also it has been added a css transition when the icon is toggled.


https://user-images.githubusercontent.com/84783765/222114612-2daab7e1-8217-49ec-bfa0-4e463cdc236e.mov

