### PR TITLE
refactor: STOR-483

### DIFF
--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -4,11 +4,23 @@
     font-size: 12px;
     margin-bottom: 8px;
     line-height: 24px;
-    color: var(--farm-text-primary);
+    color: var(--farm-bw-black-50);
+    font-weight: 600;
 
-    &.farm-label--required::after {
-        content: '*';
-        margin-left: 2px;
-        color: var(--farm-error-base);
+    &.farm-label--required:not(:has(.farm-tooltip)) {
+        &::after {
+            content: '*';
+            margin-left: 2px;
+            color: var(--farm-error-base);
+        }
+    }
+
+    &:has(.farm-tooltip) {
+        .farm-tooltip::before {
+            content: '*';
+            margin-left: 1px;
+            margin-right: 2px;
+            color: var(--farm-error-base);
+        }
     }
 }

--- a/src/components/Label/Label.stories.js
+++ b/src/components/Label/Label.stories.js
@@ -27,7 +27,6 @@ export const Primary = () => ({
 
 export const Required = () => ({
 	template: `<div>
-		<farm-label :required="true">Label</farm-label>
 		<farm-label required>Label</farm-label>
 	</div>`,
 });

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -43,7 +43,7 @@ export default Vue.extend({
 				| 'extra-1'
 				| 'extra-2'
 			>,
-			default: 'secondary',
+			default: 'secondary-green',
 		},
 		/**
 		 * Control visibility


### PR DESCRIPTION
Adjust typography (color, weight, etc...) from label and also add support in css to keep the * indicator beside the text and before the tooltip:

![Captura de Tela 2023-03-08 às 19 25 20](https://user-images.githubusercontent.com/84783765/223823609-bcd238a0-6436-42fe-bcf7-ec4b0f86de70.png)
