### PR TITLE
feat: STOR-507

### DIFF
--- a/src/components/Typography/Typography.scss
+++ b/src/components/Typography/Typography.scss
@@ -64,6 +64,16 @@
 			font-weight: $w;
 		}
 	}
+
+}
+
+.farm-typography[color=black] {
+	color: var(--farm-bw-black);
+	@each $v in $bwVariations {
+		&.farm-typography--black-#{$v} {
+			color: var(--farm-bw-black-#{$v});
+		}
+	}
 }
 
 @include upToSm {

--- a/src/components/Typography/Typography.stories.js
+++ b/src/components/Typography/Typography.stories.js
@@ -1,8 +1,11 @@
 import Typography from './Typography';
 import sizes from '../../configurations/sizes';
 import baseThemeColors from '../../configurations/_theme-colors-base.scss';
+import bwThemeColors from '../../configurations/_theme-colors-bw.scss';
 
 const colors = Object.keys(baseThemeColors);
+
+console.log(bwThemeColors);
 
 export default {
 	title: 'Typography/Atom',
@@ -91,7 +94,8 @@ export const CustomSizes = () => ({
 export const Colors = () => ({
 	data() {
 		return {
-			colors: ['default', ...colors, 'white'],
+			colors: ['default', ...colors],
+			bwColors: Object.keys(bwThemeColors),
 		};
 	},
 	template: `<div>
@@ -102,6 +106,17 @@ export const Colors = () => ({
 		>
 			Typography - color {{ color }}
 		</farm-typography>
+
+		<farm-typography
+			v-for="bw in bwColors"
+			:style="{ backgroundColor: bw === 'white' ? 'black' : 'white' }"
+			:color="bw.split('-')[0]"
+			:color-variation="bw.split('-')[1]"
+			:key="bw"
+		>
+			Typography - color {{ bw }}
+		</farm-typography>
+
 	</div>`,
 });
 

--- a/src/components/Typography/Typography.vue
+++ b/src/components/Typography/Typography.vue
@@ -8,6 +8,7 @@
 			['farm-typography--weight-' + weight]: weight !== undefined,
 			'farm-typography--lighten': colorVariation === 'lighten',
 			'farm-typography--darken': colorVariation === 'darken',
+			['farm-typography--black-' + colorVariation]: color === 'black',
 			'farm-typography--ellipsis': ellipsis,
 		}"
 		:style="style"
@@ -81,8 +82,10 @@ export default Vue.extend({
 				| 'extra-1'
 				| 'extra-2'
 				| 'gray'
+				| 'bw'
+				| 'white'
 			>,
-			default: 'default',
+			default: '',
 		},
 		/**
 		 * Color variation

--- a/src/components/Typography/Typography.vue
+++ b/src/components/Typography/Typography.vue
@@ -82,7 +82,7 @@ export default Vue.extend({
 				| 'extra-1'
 				| 'extra-2'
 				| 'gray'
-				| 'bw'
+				| 'black'
 				| 'white'
 			>,
 			default: '',

--- a/src/configurations/_variables.scss
+++ b/src/configurations/_variables.scss
@@ -28,6 +28,8 @@ $fontSizes: (
 
 $fontWeights: 100, 200, 300, 400, 500, 600, 700;
 
+$bwVariations: 80, 50, 40, 30, 10;
+
 $aligns: start,center,end,auto,baseline,stretch;
 $align-contents: start,center,end,space-between,space-around,stretch;
 $justifications: start,center,end,space-between,space-around;


### PR DESCRIPTION
Enable black and its gradient colors to be used in typography:

![Captura de Tela 2023-03-09 às 10 49 34](https://user-images.githubusercontent.com/84783765/224002282-5f104369-a981-4385-9fdb-9420c09dd9c5.png)

by props.
Example:
`<farm-typography color="black" />`
`<farm-typography color="black" variation="80" />`