### PR TITLE
fix: context menu fixed parent

### DIFF
--- a/src/components/ContextMenu/ContextMenu.stories.js
+++ b/src/components/ContextMenu/ContextMenu.stories.js
@@ -20,9 +20,9 @@ export default {
 
 export const Primary = () => ({
 	template: `<div style="padding-left: 120px; padding-top: 80px; display: flex;">
-        <farm-contextmenu>
-            some text
-            <template v-slot:activator="{ on, attrs }">
+		<farm-contextmenu>
+			some text
+			<template v-slot:activator="{ on, attrs }">
                 <farm-btn
 					v-bind="attrs"
 					v-on="on"

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -18,7 +18,7 @@
 </template>
 <script lang="ts">
 import Vue, { ref, watch, reactive, onBeforeUnmount, toRefs } from 'vue';
-import { calculateMainZindex } from '../../helpers';
+import { calculateMainZindex, isChildOfFixedElement } from '../../helpers';
 
 export default Vue.extend({
 	name: 'farm-contextmenu',
@@ -74,7 +74,7 @@ export default Vue.extend({
 		} as any);
 
 		const inputValue = ref(props.value);
-		
+
 		let hasBeenBoostrapped = false;
 
 		const outClick = event => {
@@ -130,6 +130,8 @@ export default Vue.extend({
 			if (!parent.value || !activator.value.children[0]) {
 				return;
 			}
+			const activatorChildOfFixedElement = isChildOfFixedElement(activator.value);
+
 			const parentBoundingClientRect = parent.value.getBoundingClientRect();
 			const activatorBoundingClientRect = activator.value.children[0].getBoundingClientRect();
 			const popupClientRect = popup.value.getBoundingClientRect();
@@ -173,8 +175,18 @@ export default Vue.extend({
 				offsetTop -= bottomEdge - window.scrollY - clientHeight + 12;
 			}
 
+			if (activatorChildOfFixedElement) {
+				styles.position = 'fixed';
+				offsetTop =
+					parentBoundingClientRect.top +
+					(!bottom.value ? 0 : activatorBoundingClientRect.height);
+			} else {
+				styles.position = 'absolute';
+			}
+
 			styles.top = `${offsetTop}px`;
 			styles.left = `${offsetLeft}px`;
+
 			styles.zIndex = calculateMainZindex();
 		};
 

--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -269,7 +269,7 @@ export const MultipleInitValue = () => ({
 			this.$refs.select.reset();
 		},
 	},
-	template: `<div>
+	template: `<div style="width: 400px">
 		<farm-select
 			v-model="v"
 			item-value="id"
@@ -280,15 +280,12 @@ export const MultipleInitValue = () => ({
 		/>
 		v-model: {{ v }}
 		<farm-btn @click="click">
-			reset by method
-		</farm-btn>
-		<farm-btn @click="v = null">
-			reset by value
+			reset
 		</farm-btn>
 	</div>`,
 });
 
-export const ChangeEvent = () => ({
+export const ChangeEvennt = () => ({
 	data() {
 		return {
 			v: null,

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,4 @@
 import { formatDatePickerHeader } from './formatDatePickerHeader';
 export { default as calculateMainZindex } from './calculateMainZindex';
-export { formatDatePickerHeader };
+import isChildOfFixedElement from './isChildOfFixedElement';
+export { formatDatePickerHeader, isChildOfFixedElement };

--- a/src/helpers/isChildOfFixedElement.js
+++ b/src/helpers/isChildOfFixedElement.js
@@ -1,0 +1,16 @@
+function isChildOfFixedElement(element) {
+	const parent = element.parentNode;
+
+	if (!parent || !(parent instanceof Element)) {
+		return false;
+	}
+	const style = window.getComputedStyle(parent);
+
+	if (style.position === 'fixed') {
+		return true;
+	}
+
+	return isChildOfFixedElement(parent);
+}
+
+export default isChildOfFixedElement;


### PR DESCRIPTION
When the context menu (or the Select, that uses it) is child of a fixed element, the context menu has an absolute position causing this following scenario:

https://user-images.githubusercontent.com/84783765/225690824-38e952ea-ae5e-4810-bc26-cff8f264efc1.mov

This PRs fixes it, checking whether the component is in the DOM bound to any element with position: fixed, traversing the DOM tree up and adding a fixed position to the context menu.


https://user-images.githubusercontent.com/84783765/225693158-01fc46cf-a3a7-4af3-b2a3-f6b01321ed3f.mov



