### PR TITLE
feat: STOR-529

### DIFF
--- a/src/components/DataTableHeader/DataTableHeader.scss
+++ b/src/components/DataTableHeader/DataTableHeader.scss
@@ -18,16 +18,16 @@
 
 th.sortable {
 	cursor: pointer;
+	.farm-icon::before {
+		transition: all 0.3s linear;
+	}
+	
 	&:not(.active) {
 		&:hover {
 			.farm-icon::before {
-				color: var(--farm-bw-black-30) !important;
+				color: var(--farm-bw-black-10) !important;
 			}
 		}
-	}
-
-	.header-text {
-		transition: color 0.5s ease;
 	}
 }
 

--- a/src/components/DataTableHeader/DataTableHeader.vue
+++ b/src/components/DataTableHeader/DataTableHeader.vue
@@ -19,7 +19,13 @@
 				@mouseover="changeShow($index)"
 				@mouseout="changeHidden($index)"
 			>
-				<span class="header-text" v-if="!isTHDataTableSelect(item)">
+				<span
+					class="header-text"
+					v-if="!isTHDataTableSelect(item)"
+					:title="
+						item.sortable && sortClick[$index].show ? `Ordernar por ${item.text}` : null
+					"
+				>
 					{{ item.text }}
 
 					<farm-icon


### PR DESCRIPTION
Added a lighter color to the sortable column icon that is nor sortable and when it becomes the sortable one, the color gets darker, with a smooth transition.

https://user-images.githubusercontent.com/84783765/226291350-06753ee6-2e45-4915-a920-2f968ce25aca.mov

Also a title attribute has been added to the ths elements that are sortable so the user will get a hint about the sorting behaviour:

![image](https://user-images.githubusercontent.com/84783765/226291786-70d86c79-75bc-47bc-bb91-512a2945342f.png)
 
