### PR TITLE
feat: STOR-531

### DIFF
--- a/src/components/CopyToClipboard/CopyToClipboard.stories.js
+++ b/src/components/CopyToClipboard/CopyToClipboard.stories.js
@@ -42,9 +42,21 @@ export const CustomSuccessMessage = () => ({
     </div>`,
 });
 
+export const CustomButtonColor = () => ({
+	template: `<div style="max-width: 480px; padding-top: 80px; padding-left: 80px;">
+		<farm-copytoclipboard toCopy="To be copied" button-color="error" />
+    </div>`,
+});
+
 export const CustomTooltipColor = () => ({
 	template: `<div style="max-width: 480px; padding-top: 80px; padding-left: 80px;">
 		<farm-copytoclipboard toCopy="To be copied" tooltip-color="info" />
+    </div>`,
+});
+
+export const CustomButtonAndTooltipColor = () => ({
+	template: `<div style="max-width: 480px; padding-top: 80px; padding-left: 80px;">
+		<farm-copytoclipboard toCopy="To be copied" button-color="error" tooltip-color="extra-1" />
     </div>`,
 });
 

--- a/src/components/CopyToClipboard/CopyToClipboard.vue
+++ b/src/components/CopyToClipboard/CopyToClipboard.vue
@@ -1,8 +1,8 @@
 <template>
-	<farm-tooltip v-model="show" :color="tooltipColor">
+	<farm-tooltip v-model="show" :color="tooltipColor || buttonColor">
 		{{ feedbackMessage }}
 		<template v-slot:activator="{}">
-			<farm-btn v-if="isIcon" title="Copiar" icon :disabled="disabled" @click="onClick">
+			<farm-btn v-if="isIcon" title="Copiar" icon :disabled="disabled" :color="buttonColor" @click="onClick">
 				<farm-icon :size="sizeIcon">content-copy</farm-icon>
 			</farm-btn>
 			<farm-btn v-else outlined title="Copiar" :disabled="disabled" @click="onClick">
@@ -45,6 +45,25 @@ export default Vue.extend({
 			default: 'Conteúdo copiado para a área de trabalho',
 		},
 		/**
+		 * Button color
+		 */
+		 buttonColor: {
+			type: String as PropType<
+				| 'primary'
+				| 'secondary'
+				| 'secondary-green'
+				| 'secondary-golden'
+				| 'neutral'
+				| 'info'
+				| 'success'
+				| 'error'
+				| 'warning'
+				| 'extra-1'
+				| 'extra-2'
+			>,
+			default: 'primary',
+		},
+		/**
 		 * Tooltip color
 		 */
 		tooltipColor: {
@@ -61,7 +80,7 @@ export default Vue.extend({
 				| 'extra-1'
 				| 'extra-2'
 			>,
-			default: 'primary',
+			default: null,
 		},
 		/**
 		 * Success message timeout (in ms)

--- a/src/components/IdCaption/IdCaption.stories.js
+++ b/src/components/IdCaption/IdCaption.stories.js
@@ -173,11 +173,12 @@ export const CustomSuccessMessageAfterCopyToClipboard = () => ({
     `,
 });
 
-export const CustomTooltipColor = () => ({
+export const CustomColors = () => ({
 	template: `
     <farm-idcaption 
         icon="account-box-outline"
         copy-text="Custom Success Message to be copied"
+        buttons-color="extra-1"
         tooltip-color="info"
     >
         <template v-slot:title>

--- a/src/components/IdCaption/IdCaption.vue
+++ b/src/components/IdCaption/IdCaption.vue
@@ -27,8 +27,9 @@
 				<farm-btn
 					v-if="link"
 					icon
-					color="primary"
 					class="farm-btn--clickable"
+					title="Ver mais"
+					:color="buttonsColor"
 					@click="$emit('onLinkClick')"
 				>
 					<farm-icon size="16px">open-in-new</farm-icon>
@@ -44,7 +45,8 @@
 					sizeIcon="16px"
 					:toCopy="copyText"
 					:successMessage="successMessage"
-					:tooltipColor="tooltipColor"
+					:buttonColor="buttonsColor"
+					:tooltipColor="tooltipColor || buttonsColor"
 				/>
 			</farm-caption>
 		</div>
@@ -84,6 +86,26 @@ export default Vue.extend({
 			default: 'secondary-golden',
 		},
 		/**
+		 * Buttons Color (change from link and copy to clipboard)
+		 */
+		 buttonsColor: {
+			type: String as PropType<
+				| 'primary'
+				| 'secondary-green'
+				| 'secondary-golden'
+				| 'secondary'
+				| 'neutral'
+				| 'info'
+				| 'success'
+				| 'error'
+				| 'warning'
+				| 'extra-1'
+				| 'extra-2'
+				| 'gray'
+			>,
+			default: 'primary',
+		},
+		/**
 		 * Text to be copied to clipboard
 		 */
 		copyText: {
@@ -121,7 +143,7 @@ export default Vue.extend({
 				| 'extra-1'
 				| 'extra-2'
 			>,
-			default: 'secondary',
+			default: 'primary',
 		},
 		/**
 		 * noHeight remove min-height of 48px


### PR DESCRIPTION
The copy to clipboard button in ID Caption color is primary:
![Captura de Tela 2023-03-20 às 14 14 48](https://user-images.githubusercontent.com/84783765/226370212-5526d621-c7e9-4c77-8007-5c89e4e6d69b.png)
but the tooltip color is golden:
![Captura de Tela 2023-03-20 às 14 14 45](https://user-images.githubusercontent.com/84783765/226370277-2843daf5-4553-4661-8302-290a5e2f7ed0.png)

Now the default color is also the primary:
![Captura de Tela 2023-03-20 às 14 25 38](https://user-images.githubusercontent.com/84783765/226370337-f1b5159b-3c07-4df0-9de3-98e64adc2bbc.png)


And the ID Caption and the CopyToClipboard now have props to set buttons' colors.