### PR TITLE
fix: label with * even with false prop 

### DIFF
--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -23,4 +23,11 @@
             color: var(--farm-error-base);
         }
     }
+
+    &:has(.farm-tooltip):not(.farm-label--required) {
+        .farm-tooltip::before {
+            content: '';
+            margin-left: 2px;
+        }
+    }
 }

--- a/src/components/Label/Label.stories.js
+++ b/src/components/Label/Label.stories.js
@@ -33,6 +33,20 @@ export const Required = () => ({
 
 export const Tooltip = () => ({
 	template: `<div>
+		<farm-label>
+			Label with tooltip
+			<farm-tooltip>
+				this is the tooltip!
+				<template v-slot:activator="{ on, attrs }">
+					<farm-icon size="sm" color="gray">help-circle</farm-icon>
+				</template>
+			</farm-tooltip>
+		</farm-label>
+	</div>`,
+});
+
+export const TooltipWithRequired = () => ({
+	template: `<div>
 		<farm-label required>
 			Label with tooltip
 			<farm-tooltip>

--- a/src/components/Switcher/Switcher.vue
+++ b/src/components/Switcher/Switcher.vue
@@ -51,7 +51,7 @@ export default Vue.extend({
 		 * The updated bound model<br />
 		 * _event_
 		 */
-		 input: {
+		input: {
 			type: Function,
 			// eslint-disable-next-line
 			default: (value: [String, Number]) => {},


### PR DESCRIPTION
**What was done:**
- Fixed a bug in the farm-label component, when adding the tool type the * appeared even when a required prop was false;