### PR TITLE
refactor: remove Vue dependency to create components

### DIFF
--- a/src/components/AlertBox/AlertBox.vue
+++ b/src/components/AlertBox/AlertBox.vue
@@ -46,10 +46,10 @@
 </template>
 
 <script lang="ts">
-import Vue, { ref, PropType } from 'vue';
+import { ref, PropType, defineComponent } from 'vue';
 import valueWatcher from './valueWatcher';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-alertbox',
 	props: {
 		/**

--- a/src/components/AlertReload/AlertReload.vue
+++ b/src/components/AlertReload/AlertReload.vue
@@ -18,9 +18,9 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-alert-reload',
 	props: {
 		/**

--- a/src/components/ButtonToggle/ButtonToggle.vue
+++ b/src/components/ButtonToggle/ButtonToggle.vue
@@ -12,9 +12,10 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { PropType, ref } from 'vue';
+import { PropType, ref, defineComponent } from 'vue';
 import IButtonToggle from './IButtonToggle';
-export default Vue.extend({
+
+export default defineComponent({
 	name: 'farm-button-toggle',
 	props: {
 		/**

--- a/src/components/Buttons/ConfirmButton/ConfirmButton.vue
+++ b/src/components/Buttons/ConfirmButton/ConfirmButton.vue
@@ -7,9 +7,9 @@
 	</farm-btn>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-btn-confirm',
 	inheritAttrs: true,
 	props: {

--- a/src/components/Buttons/DangerButton/DangerButton.vue
+++ b/src/components/Buttons/DangerButton/DangerButton.vue
@@ -7,9 +7,9 @@
 	</farm-btn>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-btn-danger',
 	inheritAttrs: true,
 	props: {

--- a/src/components/Buttons/DefaultButton/DefaultButton.vue
+++ b/src/components/Buttons/DefaultButton/DefaultButton.vue
@@ -19,9 +19,9 @@
 	</router-link>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-btn',
 	inheritAttrs: true,
 

--- a/src/components/Buttons/ExportButton/ExportButton.vue
+++ b/src/components/Buttons/ExportButton/ExportButton.vue
@@ -36,7 +36,7 @@
 	</farm-contextmenu>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
 export interface IExportOption {
 	label: String;
@@ -46,7 +46,7 @@ export interface IExportOption {
 /**
  * BExport Button: standalone or menu list
  */
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-btn-export',
 	props: {
 		/**

--- a/src/components/Buttons/ImportButton/ImportButton.vue
+++ b/src/components/Buttons/ImportButton/ImportButton.vue
@@ -10,9 +10,9 @@
 	</farm-btn>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-btn-import',
 	props: {
 		/**

--- a/src/components/Buttons/MultiImportButton/MultiImportButton.vue
+++ b/src/components/Buttons/MultiImportButton/MultiImportButton.vue
@@ -22,14 +22,14 @@
 	</farm-contextmenu>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
 export interface IImportOption {
 	title: String;
 	listenerKey: String;
 }
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-btn-multipleimport',
 	props: {
 		/**

--- a/src/components/Buttons/RemoveButton/RemoveButton.vue
+++ b/src/components/Buttons/RemoveButton/RemoveButton.vue
@@ -11,10 +11,10 @@
 		{{ label }}
 	</farm-btn>
 </template>
-<script>
-import Vue from 'vue';
+<script lang="ts">
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-btn-remove',
 	props: {
 		/**

--- a/src/components/Buttons/ToggleButton/ToggleButton.vue
+++ b/src/components/Buttons/ToggleButton/ToggleButton.vue
@@ -20,12 +20,12 @@
 	</farm-btn>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
 /**
  * Botão de Toggle, emitindo e guardando status
  */
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-btn-toggle',
 	data: () => ({
 		open: false,

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -5,9 +5,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-card',
 	inheritAttrs: true,
 	props: {

--- a/src/components/Card/CardContent/CardContent.vue
+++ b/src/components/Card/CardContent/CardContent.vue
@@ -9,9 +9,9 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-card-content',
 	props: {
 		/**

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -22,14 +22,14 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { computed, onBeforeMount, PropType, ref, toRefs, watch } from 'vue';
+import { computed, onBeforeMount, PropType, ref, toRefs, watch, defineComponent } from 'vue';
 import validateFormStateBuilder from '../../composition/validateFormStateBuilder';
 import validateFormFieldBuilder from '../../composition/validateFormFieldBuilder';
 import validateFormMethodBuilder from '../../composition/validateFormMethodBuilder';
 import deepEqual from '../../composition/deepEqual';
 import modelValueWatcher from './modelValueWatcher';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-checkbox',
 	model: {
 		prop: 'modelValue',

--- a/src/components/Chip/Chip.vue
+++ b/src/components/Chip/Chip.vue
@@ -15,9 +15,9 @@
 	</span>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-chip',
 	inheritAttrs: true,
 	props: {

--- a/src/components/ChipInviteStatus/ChipInviteStatus.vue
+++ b/src/components/ChipInviteStatus/ChipInviteStatus.vue
@@ -9,9 +9,9 @@
 	</farm-chip>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import keys from './keys';
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-chip-invite',
 	props: {
 		/**

--- a/src/components/Collapsible/Collapsible.vue
+++ b/src/components/Collapsible/Collapsible.vue
@@ -40,9 +40,9 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-collapsible',
 
 	props: {

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -17,10 +17,10 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { ref, watch, reactive, onBeforeUnmount, toRefs } from 'vue';
+import { ref, watch, reactive, onBeforeUnmount, toRefs, defineComponent } from 'vue';
 import { calculateMainZindex, isChildOfFixedElement } from '../../helpers';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-contextmenu',
 	props: {
 		/**

--- a/src/components/CopyToClipboard/CopyToClipboard.vue
+++ b/src/components/CopyToClipboard/CopyToClipboard.vue
@@ -21,10 +21,10 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType, ref, toRefs } from 'vue';
+import { PropType, defineComponent, ref, toRefs } from 'vue';
 import { toClipboard } from '@farm-investimentos/front-mfe-libs-ts';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-copytoclipboard',
 	props: {
 		/**

--- a/src/components/DataTableEmptyWrapper/DataTableEmptyWrapper.vue
+++ b/src/components/DataTableEmptyWrapper/DataTableEmptyWrapper.vue
@@ -15,9 +15,9 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-emptywrapper',
 	props: {
 		/**

--- a/src/components/DataTableHeader/DataTableHeader.vue
+++ b/src/components/DataTableHeader/DataTableHeader.vue
@@ -58,9 +58,9 @@
 
 <script lang="ts">
 /* eslint-disable */
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-datatable-header',
 	props: {
 		/**

--- a/src/components/DataTablePaginator/DataTablePaginator.vue
+++ b/src/components/DataTablePaginator/DataTablePaginator.vue
@@ -58,13 +58,13 @@
 	</section>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
 /**
  * Componente de paginação usado em tabelas e listas
  * com opção de itens por página
  */
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-datatable-paginator',
 	props: {
 		/**

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -51,14 +51,14 @@
 	</farm-contextmenu>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import { VDatePicker } from 'vuetify/lib/components/VDatePicker';
 import { defaultFormat as dateDefaultFormatter, convertDate } from '../../helpers/date';
 import { formatDatePickerHeader } from '../../helpers';
 /**
  * Componente de input com datepicker para data
  */
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-input-datepicker',
 	components: {
 		VDatePicker,

--- a/src/components/DialogFooter/DialogFooter.vue
+++ b/src/components/DialogFooter/DialogFooter.vue
@@ -29,13 +29,13 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 import IExtraButton from './IExtraButton';
 
 /**
  * Footer de dialog/modal
  */
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-dialog-footer',
 	props: {
 		/**

--- a/src/components/DialogHeader/DialogHeader.vue
+++ b/src/components/DialogHeader/DialogHeader.vue
@@ -20,11 +20,11 @@
 	</header>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 /**
  * Header de dialog/modal
  */
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-dialog-header',
 	props: {
 		/**

--- a/src/components/Form/Form.vue
+++ b/src/components/Form/Form.vue
@@ -2,11 +2,11 @@
 	<form class="farm-form"><slot></slot></form>
 </template>
 <script lang="ts">
-import Vue, { onMounted, reactive, ref, getCurrentInstance } from 'vue';
+import { onMounted, reactive, ref, getCurrentInstance, defineComponent } from 'vue';
 
 type ErrorsBag = Record<number, boolean>;
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-form',
 	props: {
 		value: { type: [Boolean] },

--- a/src/components/Icon/Icon.vue
+++ b/src/components/Icon/Icon.vue
@@ -2,11 +2,11 @@
 	<i v-on="$listeners" v-bind="$attrs" :class="classes" :size="$props.size" ref="el" />
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
 const breakPoints = ['xs', 'sm', 'md', 'lg', 'xl'];
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-icon',
 	inheritAttrs: true,
 

--- a/src/components/IconBox/IconBox.vue
+++ b/src/components/IconBox/IconBox.vue
@@ -14,9 +14,9 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-icon-box',
 	props: {
 		/**

--- a/src/components/IdCaption/IdCaption.vue
+++ b/src/components/IdCaption/IdCaption.vue
@@ -54,8 +54,8 @@
 </template>
 
 <script lang="ts">
-import Vue, { computed, PropType } from 'vue';
-export default Vue.extend({
+import { computed, PropType, defineComponent } from 'vue';
+export default defineComponent({
 	name: 'farm-idcaption',
 	props: {
 		/**

--- a/src/components/Label/Label.vue
+++ b/src/components/Label/Label.vue
@@ -8,9 +8,9 @@
 	</label>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-label',
 	props: {
 		/**

--- a/src/components/List/List.vue
+++ b/src/components/List/List.vue
@@ -4,10 +4,10 @@
 	</ul>
 </template>
 <script lang="ts">
-import Vue, { onMounted, onUnmounted, ref } from 'vue';
+import { defineComponent, onMounted, onUnmounted, ref } from 'vue';
 import { useFocus } from './composition';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-list',
 	setup(_, { emit }) {
 		const contentRef = ref<HTMLElement>();

--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -16,9 +16,9 @@
 	</li>
 </template>
 <script lang="ts">
-import Vue, { computed, PropType, toRefs } from 'vue';
+import { defineComponent, computed, PropType, toRefs } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-listitem',
 	props: {
 		to: {

--- a/src/components/Loader/Loader.vue
+++ b/src/components/Loader/Loader.vue
@@ -51,10 +51,10 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import { calculateMainZindex } from '../../helpers';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-loader',
 	props: {
 		mode: {

--- a/src/components/Logger/Logger.vue
+++ b/src/components/Logger/Logger.vue
@@ -14,10 +14,10 @@
 	</section>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import ILoggerItem from './LoggerItem/ILoggerItem';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-logger',
 	props: {
 		/*

--- a/src/components/Logger/LoggerItem/LoggerItem.vue
+++ b/src/components/Logger/LoggerItem/LoggerItem.vue
@@ -50,11 +50,11 @@
 	</section>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import ILoggerItem from './ILoggerItem';
 import mappingIconKeys from './mappingIconKeys';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-logger-item',
 	props: {
 		/**

--- a/src/components/Logos/OriginatorLogo/OriginatorLogo.vue
+++ b/src/components/Logos/OriginatorLogo/OriginatorLogo.vue
@@ -2,9 +2,9 @@
 	<img :src="imgSrc" />
 </template>
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-imglogo-originator',
 	inheritAttrs: true,
 	props: {

--- a/src/components/Logos/ProductLogo/ProductLogo.vue
+++ b/src/components/Logos/ProductLogo/ProductLogo.vue
@@ -2,9 +2,9 @@
 	<img :src="imgSrc" />
 </template>
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-imglogo-product',
 	inheritAttrs: true,
 	props: {

--- a/src/components/MainFilter/MainFilter.vue
+++ b/src/components/MainFilter/MainFilter.vue
@@ -28,9 +28,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-form-mainfilter',
 	props: {
 		/**

--- a/src/components/ManagersList/ManagersList.vue
+++ b/src/components/ManagersList/ManagersList.vue
@@ -6,8 +6,8 @@
 	</ul>
 </template>
 <script lang="ts">
-import Vue from 'vue';
-export default Vue.extend({
+import { defineComponent } from 'vue';
+export default defineComponent({
 	name: 'farm-managers-list',
 	props: {
 		managersString: {

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -27,10 +27,19 @@
 </template>
 
 <script lang="ts">
-import Vue, { onBeforeUnmount, onMounted, PropType, reactive, ref, toRefs, watch } from 'vue';
+import {
+	defineComponent,
+	onBeforeUnmount,
+	onMounted,
+	PropType,
+	reactive,
+	ref,
+	toRefs,
+	watch,
+} from 'vue';
 import { calculateMainZindex } from '../../helpers';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-modal',
 	props: {
 		/**

--- a/src/components/ModalPromptUser/ModalPromptUser.vue
+++ b/src/components/ModalPromptUser/ModalPromptUser.vue
@@ -31,9 +31,9 @@
 	</farm-modal>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-prompt-user',
 	props: {
 		/**

--- a/src/components/MultipleFilePicker/MultipleFilePicker.vue
+++ b/src/components/MultipleFilePicker/MultipleFilePicker.vue
@@ -13,7 +13,8 @@
 				cloud-upload-outline
 			</farm-icon>
 			<farm-subtitle :type="2" variation="regular" color="primary">
-				Arraste e solte o arquivo <br/> ou clique aqui
+				Arraste e solte o arquivo <br />
+				ou clique aqui
 			</farm-subtitle>
 		</div>
 
@@ -30,7 +31,7 @@
 						<farm-icon color="black" variation="50" size="sm">attachment</farm-icon>
 					</div>
 					<div>
-						<farm-bodysmall  color="black" color-variation="50">
+						<farm-bodysmall color="black" color-variation="50">
 							Arquivo selecionado: {{ file.name }} ({{ sizeOf(file.size) }})
 						</farm-bodysmall>
 					</div>
@@ -57,12 +58,11 @@
 		<ul class="listFilesStyled" v-if="files.length > 0">
 			<li class="itemFilesStyled" v-for="(file, index) in files" :key="index">
 				<div class="itemFilesContentStyled">
-					
 					<div class="fileDocumentStyled">
 						<farm-icon color="black" variation="50" size="sm">attachment</farm-icon>
 					</div>
 					<div>
-						<farm-bodysmall  color="black" color-variation="50">
+						<farm-bodysmall color="black" color-variation="50">
 							Arquivo selecionado: {{ file.name }} ({{ sizeOf(file.size) }})
 						</farm-bodysmall>
 					</div>
@@ -95,7 +95,7 @@
 	</section>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 import { sizeOf } from '@farm-investimentos/front-mfe-libs-ts';
 
 export type DownloadFiles = {
@@ -104,7 +104,7 @@ export type DownloadFiles = {
 	size: number;
 };
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-multiple-filepicker',
 
 	props: {

--- a/src/components/MultipleSelectShortener/MultipleSelectShortener.vue
+++ b/src/components/MultipleSelectShortener/MultipleSelectShortener.vue
@@ -8,8 +8,8 @@
 </template>
 
 <script>
-import Vue from 'vue';
-export default Vue.extend({
+import { defineComponent } from 'vue';
+export default defineComponent({
 	name: 'farm-multiple-select-shortener',
 	props: {
 		/**

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -4,9 +4,9 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-progressbar',
 	props: {
 		/**

--- a/src/components/PromptUserToConfirm/PromptUserToConfirm.vue
+++ b/src/components/PromptUserToConfirm/PromptUserToConfirm.vue
@@ -9,8 +9,8 @@
 	</farm-form>
 </template>
 <script lang="ts">
-import Vue from 'vue';
-export default Vue.extend({
+import { defineComponent } from 'vue';
+export default defineComponent({
 	name: 'farm-promptusertoconfirm',
 	props: {
 		/**

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -20,9 +20,9 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-radio',
 	model: {
 		prop: 'modelValue',

--- a/src/components/RadioGroup/RadioGroup.vue
+++ b/src/components/RadioGroup/RadioGroup.vue
@@ -11,13 +11,13 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { ref, watch, PropType, toRefs, computed, onBeforeMount } from 'vue';
+import { defineComponent, ref, watch, PropType, toRefs, computed, onBeforeMount } from 'vue';
 import validateFormStateBuilder from '../../composition/validateFormStateBuilder';
 import validateFormFieldBuilder from '../../composition/validateFormFieldBuilder';
 import validateFormMethodBuilder from '../../composition/validateFormMethodBuilder';
 import deepEqual from '../../composition/deepEqual';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-radio-group',
 	props: {
 		/**

--- a/src/components/RangeDatePicker/RangeDatePicker.vue
+++ b/src/components/RangeDatePicker/RangeDatePicker.vue
@@ -52,14 +52,15 @@
 	</farm-contextmenu>
 </template>
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import { VDatePicker } from 'vuetify/lib/components/VDatePicker';
 import { defaultFormat as dateDefaultFormatter } from '../../helpers/date';
 import { formatDatePickerHeader } from '../../helpers';
+
 /**
  * Componente de input com datepicker para range de data
  */
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-input-rangedatepicker',
 	components: {
 		VDatePicker,
@@ -178,7 +179,7 @@ export default Vue.extend({
 			return true;
 		},
 		isInvertedDate() {
-			if ((Array.isArray(this.dateField)) && this.dateField.length === 2) {
+			if (Array.isArray(this.dateField) && this.dateField.length === 2) {
 				const firstDate = new Date(this.dateField[0]);
 				const secondDate = new Date(this.dateField[1]);
 				return firstDate.getTime() > secondDate.getTime();

--- a/src/components/ResetTableRowSelection/ResetTableRowSelection.stories.js
+++ b/src/components/ResetTableRowSelection/ResetTableRowSelection.stories.js
@@ -11,5 +11,5 @@ export const Primary = () => ({
 			items: [1, 2, 3],
 		};
 	},
-	template: `<ResetTableRowSelection v-model="items" />`,
+	template: `<ResetTableRowSelection :length="items.length" />`,
 });

--- a/src/components/ResetTableRowSelection/ResetTableRowSelection.vue
+++ b/src/components/ResetTableRowSelection/ResetTableRowSelection.vue
@@ -8,11 +8,11 @@
 	</div>
 </template>
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import VIcon from 'vuetify/lib/components/VIcon';
 import DefaultButton from '../Buttons/DefaultButton';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-tablerowselection',
 	components: {
 		VIcon,

--- a/src/components/ResetTableRowSelection/ResetTableRowSelection.vue
+++ b/src/components/ResetTableRowSelection/ResetTableRowSelection.vue
@@ -1,23 +1,17 @@
 <template>
 	<div class="ml-6 mr-3 d-flex align-center">
 		Total de linhas selecionadas: {{ length }}
-		<farm-btn color="error" @click="reset" small dense class="ml-3" v-if="length > 0">
-			<v-icon small> mdi-trash-can </v-icon>
+		<farm-btn color="error" @click="reset" small class="ml-3" v-if="length > 0">
+			<farm-icon size="sm">trash-can </farm-icon>
 			Desmarcar
 		</farm-btn>
 	</div>
 </template>
 <script>
 import { defineComponent } from 'vue';
-import VIcon from 'vuetify/lib/components/VIcon';
-import DefaultButton from '../Buttons/DefaultButton';
 
 export default defineComponent({
 	name: 'farm-tablerowselection',
-	components: {
-		VIcon,
-		'farm-btn': DefaultButton,
-	},
 	props: {
 		/**
 		 * Current items length selected

--- a/src/components/ResourceMetaInfo/ResourceMetaInfo.vue
+++ b/src/components/ResourceMetaInfo/ResourceMetaInfo.vue
@@ -30,7 +30,7 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { computed, PropType, toRefs } from 'vue';
+import { computed, defineComponent, PropType, toRefs } from 'vue';
 
 interface ResourceMetaInfoProps {
 	createdAt: string;
@@ -39,7 +39,7 @@ interface ResourceMetaInfoProps {
 	updatedHours: string;
 }
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-resource-metainfo',
 	props: {
 		/**

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -90,7 +90,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { computed, onBeforeMount, PropType, ref, toRefs, watch } from 'vue';
+import { computed, onBeforeMount, PropType, ref, toRefs, watch, defineComponent } from 'vue';
 import validateFormStateBuilder from '../../composition/validateFormStateBuilder';
 import validateFormFieldBuilder from '../../composition/validateFormFieldBuilder';
 import validateFormMethodBuilder from '../../composition/validateFormMethodBuilder';
@@ -98,7 +98,7 @@ import deepEqual from '../../composition/deepEqual';
 import randomId from '../../helpers/randomId';
 import { buildData } from './composition';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-select',
 	inheritAttrs: true,
 	props: {

--- a/src/components/SelectModalOptions/SelectModalOptions.vue
+++ b/src/components/SelectModalOptions/SelectModalOptions.vue
@@ -78,10 +78,10 @@
 	</farm-col>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import { VDataTable } from 'vuetify/lib';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-select-modal-options',
 	components: {
 		'v-data-table': VDataTable,

--- a/src/components/Stepper/StepperHeader/StepperHeader.vue
+++ b/src/components/Stepper/StepperHeader/StepperHeader.vue
@@ -40,10 +40,10 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 import IStep from './IStep';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-stepper-header',
 	props: {
 		/**

--- a/src/components/Switcher/Switcher.vue
+++ b/src/components/Switcher/Switcher.vue
@@ -11,9 +11,9 @@
 	</div>
 </template>
 <script lang="ts">
-import Vue, { PropType, computed, ref, watch } from 'vue';
+import { defineComponent, PropType, computed, ref, watch } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-switcher',
 	props: {
 		/**

--- a/src/components/TableContextMenu/TableContextMenu.vue
+++ b/src/components/TableContextMenu/TableContextMenu.vue
@@ -26,13 +26,15 @@
 				<farm-icon v-if="item.icon" size="sm" :color="item.icon.color || 'primary'">
 					{{ item.icon.type }}
 				</farm-icon>
-				<farm-caption bold tag="span" :color="item.icon.color || 'primary'">{{ item.label }}</farm-caption>
+				<farm-caption bold tag="span" :color="item.icon.color || 'primary'">{{
+					item.label
+				}}</farm-caption>
 			</farm-listitem>
 		</farm-list>
 	</farm-contextmenu>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
 export interface IContextMenuOption {
 	label: string;
@@ -45,7 +47,7 @@ export interface IContextMenuOptionIcon {
 	type: string;
 }
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-context-menu',
 	components: {},
 	props: {

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -43,8 +43,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-export default Vue.extend({
+import { defineComponent } from 'vue';
+
+export default defineComponent({
 	name: 'farm-tabs',
 	data() {
 		return {

--- a/src/components/TextArea/TextArea.vue
+++ b/src/components/TextArea/TextArea.vue
@@ -49,14 +49,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { computed, onBeforeMount, PropType, ref, toRefs, watch } from 'vue';
+import { defineComponent, computed, onBeforeMount, PropType, ref, toRefs, watch } from 'vue';
 import validateFormStateBuilder from '../../composition/validateFormStateBuilder';
 import validateFormFieldBuilder from '../../composition/validateFormFieldBuilder';
 import validateFormMethodBuilder from '../../composition/validateFormMethodBuilder';
 import deepEqual from '../../composition/deepEqual';
 import randomId from '../../helpers/randomId';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-textarea',
 	inheritAttrs: true,
 	props: {

--- a/src/components/TextFieldV2/TextFieldV2.vue
+++ b/src/components/TextFieldV2/TextFieldV2.vue
@@ -66,14 +66,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { computed, onBeforeMount, PropType, ref, toRefs, watch } from 'vue';
+import { defineComponent, computed, onBeforeMount, PropType, ref, toRefs, watch } from 'vue';
 import validateFormStateBuilder from '../../composition/validateFormStateBuilder';
 import validateFormFieldBuilder from '../../composition/validateFormFieldBuilder';
 import validateFormMethodBuilder from '../../composition/validateFormMethodBuilder';
 import deepEqual from '../../composition/deepEqual';
 import randomId from '../../helpers/randomId';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-textfield-v2',
 	inheritAttrs: true,
 	props: {

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -20,10 +20,10 @@
 	</span>
 </template>
 <script lang="ts">
-import Vue, { PropType, ref, computed, reactive, onBeforeUnmount } from 'vue';
+import { PropType, ref, computed, reactive, onBeforeUnmount, defineComponent } from 'vue';
 import { calculateMainZindex } from '../../helpers';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-tooltip',
 	props: {
 		/*

--- a/src/components/Typography/BodyText/BodyText.vue
+++ b/src/components/Typography/BodyText/BodyText.vue
@@ -11,10 +11,10 @@
 	</farm-typography>
 </template>
 <script lang="ts">
-import Vue, { computed, ref, watch, toRefs, PropType } from 'vue';
+import { defineComponent, computed, ref, watch, toRefs, PropType } from 'vue';
 import { Keys } from './configurations';
 
-export default Vue.extend({
+export default defineComponent({
 	inheritAttrs: true,
 	name: 'farm-bodytext',
 	props: {

--- a/src/components/Typography/Caption/Caption.vue
+++ b/src/components/Typography/Caption/Caption.vue
@@ -11,11 +11,11 @@
 	</farm-typography>
 </template>
 <script lang="ts">
-import Vue, { computed, ref, watch, toRefs, PropType } from 'vue';
+import { defineComponent, computed, ref, watch, toRefs, PropType } from 'vue';
 
 import { Keys } from './configurations';
 
-export default Vue.extend({
+export default defineComponent({
 	inheritAttrs: true,
 	name: 'farm-caption',
 	props: {

--- a/src/components/Typography/Heading/Heading.vue
+++ b/src/components/Typography/Heading/Heading.vue
@@ -12,11 +12,11 @@
 	</farm-typography>
 </template>
 <script lang="ts">
-import Vue, { computed, ref, watch, toRefs, PropType } from 'vue';
+import { defineComponent, computed, ref, watch, toRefs, PropType } from 'vue';
 
 import { Keys } from './configurations';
 
-export default Vue.extend({
+export default defineComponent({
 	inheritAttrs: true,
 	name: 'farm-heading',
 	props: {

--- a/src/components/Typography/OverlayText/OverlayText.vue
+++ b/src/components/Typography/OverlayText/OverlayText.vue
@@ -10,9 +10,9 @@
 	</farm-typography>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	inheritAttrs: true,
 	name: 'farm-overlaytext',
 });

--- a/src/components/Typography/Small/Small.vue
+++ b/src/components/Typography/Small/Small.vue
@@ -11,11 +11,11 @@
 	</farm-typography>
 </template>
 <script lang="ts">
-import Vue, { computed, ref, watch, toRefs, PropType } from 'vue';
+import { defineComponent, computed, ref, watch, toRefs, PropType } from 'vue';
 
 import { Keys } from './configurations';
 
-export default Vue.extend({
+export default defineComponent({
 	inheritAttrs: true,
 	name: 'farm-bodysmall',
 	props: {

--- a/src/components/Typography/Subtitle/Subtitle.vue
+++ b/src/components/Typography/Subtitle/Subtitle.vue
@@ -11,11 +11,11 @@
 	</farm-typography>
 </template>
 <script lang="ts">
-import Vue, { computed, ref, watch, toRefs, PropType } from 'vue';
+import { defineComponent, computed, ref, watch, toRefs, PropType } from 'vue';
 
 import { Keys } from './configurations';
 
-export default Vue.extend({
+export default defineComponent({
 	inheritAttrs: true,
 	name: 'farm-subtitle',
 	props: {

--- a/src/components/Typography/Typography.vue
+++ b/src/components/Typography/Typography.vue
@@ -18,11 +18,11 @@
 	</component>
 </template>
 <script lang="ts">
-import Vue, { computed, PropType, ref, toRefs } from 'vue';
+import { defineComponent, computed, PropType, ref, toRefs } from 'vue';
 import breakPoints from '../../configurations/sizes';
 import typographyHtmlTags from '../../configurations/typographyHtmlTags';
 
-export default Vue.extend({
+export default defineComponent({
 	inheritAttrs: true,
 	name: 'farm-typography',
 	props: {

--- a/src/components/ValueCaption/ValueCaption.vue
+++ b/src/components/ValueCaption/ValueCaption.vue
@@ -14,8 +14,9 @@
 </template>
 
 <script lang="ts">
-import Vue, { computed, PropType } from 'vue';
-export default Vue.extend({
+import { computed, PropType, defineComponent } from 'vue';
+
+export default defineComponent({
 	name: 'farm-valuecaption',
 	props: {
 		/**

--- a/src/components/layout/Box/Box.vue
+++ b/src/components/layout/Box/Box.vue
@@ -12,9 +12,9 @@
 	</component>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-box',
 	props: {
 		/**

--- a/src/components/layout/Col/Col.vue
+++ b/src/components/layout/Col/Col.vue
@@ -22,9 +22,9 @@
 	</component>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-col',
 	props: {
 		/**

--- a/src/components/layout/Container/Container.vue
+++ b/src/components/layout/Container/Container.vue
@@ -6,9 +6,9 @@
 	</section>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-container',
 	inheritAttrs: true,
 });

--- a/src/components/layout/ContainerFooter/ContainerFooter.vue
+++ b/src/components/layout/ContainerFooter/ContainerFooter.vue
@@ -9,9 +9,9 @@
 	</footer>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-container-footer',
 	props: {
 		noTop: {

--- a/src/components/layout/Line/Line.vue
+++ b/src/components/layout/Line/Line.vue
@@ -11,9 +11,9 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-line',
 	props: {
 		/**

--- a/src/components/layout/Row/Row.vue
+++ b/src/components/layout/Row/Row.vue
@@ -15,9 +15,9 @@
 	</component>
 </template>
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'farm-row',
 	props: {
 		/**


### PR DESCRIPTION
Use of defineComponent instead of Vue.extend.
This aims the migration for Vue 3 in the future.