### PR TITLE
feat: TextField show validation error after blur

### DIFF
--- a/src/components/TextFieldV2/TextFieldV2.scss
+++ b/src/components/TextFieldV2/TextFieldV2.scss
@@ -62,7 +62,8 @@
 	}
 }
 
-.farm-textfield--touched.farm-textfield--validatable {
+
+.farm-textfield--touched.farm-textfield--blured.farm-textfield--validatable {
 	&.farm-textfield--error {
 		.farm-textfield {
 			&--input {

--- a/src/components/TextFieldV2/TextFieldV2.vue
+++ b/src/components/TextFieldV2/TextFieldV2.vue
@@ -186,7 +186,7 @@ export default defineComponent({
 		});
 		const customId = 'farm-textfield-' + (props.id || randomId(2));
 
-		const showErrorText = computed(() => hasError.value && isTouched.value);
+		const showErrorText = computed(() => hasError.value && isTouched.value && isBlured.value);
 
 		watch(
 			() => props.value,


### PR DESCRIPTION
Show error message only after input lost focus, so the first user interaction won't show error until the field is blured.

![Gravação de Tela 2023-05-04 às 11 04 33](https://user-images.githubusercontent.com/84783765/236174728-ecd16964-5fb8-4ecd-8f55-6d2203665070.gif)
