### PR TITLE
feat: add ability to select only allowed dates in datepicker

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.js
+++ b/src/components/DatePicker/DatePicker.stories.js
@@ -77,14 +77,23 @@ export const IsNull = () => ({
     </div>`,
 });
 
-export const BottomFalse = () => ({
+export const OnlyAllowedDates = () => ({
 	data() {
 		return {
-			date: '2023-08-01',
+			date: '',
 		};
 	},
-	template: `<div style='max-width: 320px'><farm-input-datepicker position="bottom" inputId="input-custom-id-1" v-model="date" /></div>`,
+	props: {
+		allowedDates: {
+			default: () => (value) => {
+				const day = parseInt(value.split('-')[2], 10);
+				return [5, 10, 15, 20, 25].includes(day);
+			}
+		}
+	},
+	template: `<div style='max-width: 320px'><farm-input-datepicker position="bottom" :allowed-dates="allowedDates" inputId="input-custom-id-1" v-model="date" /></div>`,
 });
+
 export const TopPositioned = () => ({
 	data() {
 		return {

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -19,6 +19,7 @@
 			:header-date-format="formatDatePickerHeader"
 			:max="max"
 			:min="min"
+			:allowed-dates="allowedDates"
 		>
 			<farm-btn plain title="Limpar" color="primary" :disabled="isDisabled" @click="clear">
 				Limpar
@@ -45,7 +46,7 @@
 				:readonly="readonly"
 				:mask="`${readonly ? '' : '##/##/####'}`"
 				:id="inputId"
-				:rules="[checkDateValid, checkMax, checkMin, checkRequire]"
+				:rules="[checkDateValid, checkMax, checkMin, checkRequire, checkIsInAllowedDates]"
 				@keyup="keyUpInput"
 			/>
 		</template>
@@ -105,6 +106,13 @@ export default defineComponent({
 			default: 'bottom',
 		},
 		/**
+		 * Allowed dates to be selected and validated
+		 */
+		allowedDates: {
+			type: Function,
+			default: () => {},
+		},
+		/**
 		 * Required field (inside form)
 		 */
 		required: {
@@ -153,6 +161,15 @@ export default defineComponent({
 					return 'A data está fora do período permitido';
 				}
 				return true;
+			},
+			checkIsInAllowedDates: value => {
+				const dateSelected = convertDate(value);
+
+				if (!this.required && value.length === 0) {
+					return true;
+				}
+
+				return this.allowedDates(dateSelected) || 'Data inválida';
 			},
 		};
 	},


### PR DESCRIPTION
Reflect Vuetify `allowed dates` property for datepicker: https://v2.vuetifyjs.com/en/components/date-pickers/#allowed-dates