### PR TITLE
refact: SCAD-2099

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	],
 	"dependencies": {
 		"core-js": "^3.6.5",
+		"pnpm": "^8.7.6",
 		"vue": "2.7.10",
 		"vuetify": "^2.4.5"
 	},

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 	],
 	"dependencies": {
 		"core-js": "^3.6.5",
-		"pnpm": "^8.7.6",
 		"vue": "2.7.10",
 		"vuetify": "^2.4.5"
 	},

--- a/src/components/Collapsible/Collapsible.stories.js
+++ b/src/components/Collapsible/Collapsible.stories.js
@@ -68,7 +68,7 @@ export const ExportDisabled = () => ({
 		};
 	},
 	template: `<div>
-		clicked: {{clicked}} <farm-collapsible disabled icon="clipboard" title="With Button" :hasButton="true"  @onClick="value => clicked = !clicked" >collapsible content</farm-collapsible>
+		clicked: {{clicked}} <farm-collapsible :disabledButton="true" icon="clipboard" title="With Button" :hasButton="true"  @onClick="value => clicked = !clicked" >collapsible content</farm-collapsible>
 		</div>`,
 });
 

--- a/src/components/Collapsible/Collapsible.stories.js
+++ b/src/components/Collapsible/Collapsible.stories.js
@@ -61,6 +61,17 @@ export const Export = () => ({
 		</div>`,
 });
 
+export const ExportDisabled = () => ({
+	data() {
+		return {
+			clicked: false,
+		};
+	},
+	template: `<div>
+		clicked: {{clicked}} <farm-collapsible disabled icon="clipboard" title="With Button" :hasButton="true"  @onClick="value => clicked = !clicked" >collapsible content</farm-collapsible>
+		</div>`,
+});
+
 export const Opened = () => ({
 	data() {
 		return {

--- a/src/components/Collapsible/Collapsible.vue
+++ b/src/components/Collapsible/Collapsible.vue
@@ -99,7 +99,7 @@ export default defineComponent({
 			default: false,
 		},
 		/**
-		 * Has export button but is disabled
+		 * export button disabled toggle
 		 */
 		disabled: {
 			type: Boolean,

--- a/src/components/Collapsible/Collapsible.vue
+++ b/src/components/Collapsible/Collapsible.vue
@@ -11,7 +11,13 @@
 					<farm-heading type="6" color="black">
 						{{ title }}
 					</farm-heading>
-					<farm-btn outlined class="ml-6" v-if="hasButton" @click.stop="onClick()">
+					<farm-btn
+						outlined
+						class="ml-6"
+						v-if="hasButton"
+						:disabled="disabled"
+						@click.stop="onClick()"
+					>
 						{{ labelButton }}
 					</farm-btn>
 				</div>
@@ -93,7 +99,14 @@ export default defineComponent({
 			default: false,
 		},
 		/**
-		 * export button
+		 * Has export button but is disabled
+		 */
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * export button emit
 		 */
 		onExport: {
 			type: Boolean,

--- a/src/components/Collapsible/Collapsible.vue
+++ b/src/components/Collapsible/Collapsible.vue
@@ -15,7 +15,7 @@
 						outlined
 						class="ml-6"
 						v-if="hasButton"
-						:disabled="disabled"
+						:disabled="disabledButton"
 						@click.stop="onClick()"
 					>
 						{{ labelButton }}
@@ -101,7 +101,7 @@ export default defineComponent({
 		/**
 		 * export button disabled toggle
 		 */
-		disabled: {
+		disabledButton: {
 			type: Boolean,
 			default: false,
 		},


### PR DESCRIPTION
Added a props to disable the export button on collapsible

this component had a withButton props which toggle the button render, if its false the export button won't show on layout.

now i added a new props which the button still shows but is disabled.

DOC: [Webpack App](https://storybook.plataforma.portalfarm.com.br/index.html?path=/docs/surfaces-collapsible--primary) 

PREVIEW: 
![image](https://github.com/Farm-Investimentos/front-mfe-components/assets/55860684/4da54eda-5928-4988-9392-48f02672cbcd)