### PR TITLE
feat: novo datepicker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+*.vue.ts
+*.vue.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
 	"semi": true,
 	"printWidth": 100,
 	"tabWidth": 4,
-	"useTabs": true
+	"useTabs": true,
+	"singleAttributePerLine": true
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,9 +14,9 @@ import 'vuetify/styles';
 
 import { createVuetify } from 'vuetify';
 // import * as vuetifyComponents from 'vuetify/components';
-import {
-	VDataTable,
-} from "vuetify/labs/VDataTable";
+import { VDataTable } from 'vuetify/labs/VDataTable';
+import VueDatePicker from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
 
 const vuetify = createVuetify({
 	components: {
@@ -52,4 +52,5 @@ setup(app => {
 
 	app.directive('mask', vMaskV3);
 	app.use(vuetify);
+	app.component('VueDatePicker', VueDatePicker);
 });

--- a/package.json
+++ b/package.json
@@ -22,10 +22,8 @@
     "src/*"
   ],
   "dependencies": {
-    "@date-io/date-fns": "^2.17.0",
     "@vuepic/vue-datepicker": "^7.1.0",
     "core-js": "^3.6.5",
-    "date-fns": "^2.30.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vue": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "src/*"
   ],
   "dependencies": {
+    "@date-io/date-fns": "^2.17.0",
+    "@vuepic/vue-datepicker": "^7.1.0",
     "core-js": "^3.6.5",
+    "date-fns": "^2.30.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vue": "3.3.4",

--- a/src/components/Checkbox/Checkbox.stories.js
+++ b/src/components/Checkbox/Checkbox.stories.js
@@ -171,3 +171,24 @@ export const ResetByMethod = () => ({
 		<farm-btn @click="$refs.checkbox.reset()">reset</farm-btn>
 	</div>`,
 });
+
+export const ChangeEvent = () => ({
+	setup() {
+
+		const select = () => {
+			alert('Updated model value');
+		}
+
+		return {
+			select
+		}
+	},
+	data() {
+		return {
+			isChecked: true,
+		};
+	},
+	template: `<div>
+		<farm-checkbox v-model="isChecked" :value="true" ref="checkbox" @update:modelValue="select($event)" />
+	</div>`,
+});

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -230,7 +230,7 @@ export default {
 
 		const click = () => {
 			inputValue.value = !inputValue.value;
-			emit('input', inputValue.value);
+			emit('update:modelValue', inputValue.value);
 		};
 
 		return {

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -14,48 +14,5 @@
 	width: 100%;
 }
 
-/*
-.v-picker ::v-deep   {
-	@import './vDatePicker.scss';
-}
-*/
+@import './customDatePicker.scss';
 
-.dp__main {
-	font-family: inherit;
-	justify-content: center;
-
-	:deep(.dp__cell_inner) {
-		font-size: 12px;
-		font-weight: 500;
-		color: var(--farm-neutral-darken);
-
-		&.dp__cell_offset {
-			color: var(--farm-gray-lighten);
-		}
-	}
-
-	:deep(.dp__menu) {
-		border: 0;
-	}
-
-	:deep(.dp--tp-wrap) {
-		display: none;
-	}
-
-	:deep(.dp__active_date) {
-		background-color: var(--farm-primary-base);
-		color: white;
-	}
-
-	:deep(.dp__today) {
-		border: 1px solid var(--farm-primary-base);
-	}
-}
-
-.picker__actions {
-	padding: 16px 8px 0;
-	border-top: 1px solid var(--farm-stroke-base);
-	margin-bottom: 16px;
-	margin-left: -4px;
-	margin-right: -4px;
-}

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -20,30 +20,42 @@
 }
 */
 
-.dp__main ::v-deep {
+.dp__main {
 	font-family: inherit;
 	justify-content: center;
 
-	.dp__menu {
+	:deep(.dp__cell_inner) {
+		font-size: 12px;
+		font-weight: 500;
+		color: var(--farm-neutral-darken);
+
+		&.dp__cell_offset {
+			color: var(--farm-gray-lighten);
+		}
+	}
+
+	:deep(.dp__menu) {
 		border: 0;
 	}
 
-	.dp--tp-wrap {
+	:deep(.dp--tp-wrap) {
 		display: none;
 	}
 
-	.dp__active_date {
+	:deep(.dp__active_date) {
 		background-color: var(--farm-primary-base);
+		color: white;
 	}
-	.dp__today {
+
+	:deep(.dp__today) {
 		border: 1px solid var(--farm-primary-base);
 	}
 }
 
 .picker__actions {
-    padding: 16px 8px 0;
-    border-top: 1px solid var(--farm-stroke-base);
-    margin-bottom: 16px;
-    margin-left: -4px;
-    margin-right: -4px;
+	padding: 16px 8px 0;
+	border-top: 1px solid var(--farm-stroke-base);
+	margin-bottom: 16px;
+	margin-left: -4px;
+	margin-right: -4px;
 }

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -14,6 +14,36 @@
 	width: 100%;
 }
 
+/*
 .v-picker ::v-deep   {
 	@import './vDatePicker.scss';
+}
+*/
+
+.dp__main ::v-deep {
+	font-family: inherit;
+	justify-content: center;
+
+	.dp__menu {
+		border: 0;
+	}
+
+	.dp--tp-wrap {
+		display: none;
+	}
+
+	.dp__active_date {
+		background-color: var(--farm-primary-base);
+	}
+	.dp__today {
+		border: 1px solid var(--farm-primary-base);
+	}
+}
+
+.picker__actions {
+    padding: 16px 8px 0;
+    border-top: 1px solid var(--farm-stroke-base);
+    margin-bottom: 16px;
+    margin-left: -4px;
+    margin-right: -4px;
 }

--- a/src/components/DatePicker/DatePicker.stories.js
+++ b/src/components/DatePicker/DatePicker.stories.js
@@ -41,15 +41,17 @@ export const MinMaxDates = () => ({
 	data() {
 		return {
 			date: '',
+			min: '2022-07-01',
+			max: '2022-12-02',
 		};
 	},
 	template: `<div style='max-width: 320px'>
-        <farm-input-datepicker inputId="input-custom-id-2" max="2021-12-02" min="2021-07-01" v-model="date" />
-        max="2021-12-02" min="2021-07-01"
+        <farm-input-datepicker inputId="input-custom-id-2" :max="max" :min="min" v-model="date" />
+        max {{ max }} min {{ min }}
     </div>`,
 });
 
-export const RequiredDates = () => ({
+export const RequiredDate = () => ({
 	data() {
 		return {
 			date: '',
@@ -61,8 +63,13 @@ export const RequiredDates = () => ({
 });
 
 export const Readonly = () => ({
+	data() {
+		return {
+			date: '2021-08-01',
+		};
+	},
 	template: `<div style='max-width: 320px'>
-        <farm-input-datepicker :readonly="true"  value="2021-08-01" inputId="input-custom-id-3"/>
+        <farm-input-datepicker :readonly="true" v-model="date" inputId="input-custom-id-3"/>
     </div>`,
 });
 
@@ -81,17 +88,12 @@ export const OnlyAllowedDates = () => ({
 	data() {
 		return {
 			date: '',
+			allowedDays: [5, 10, 15, 20, 25],
 		};
 	},
-	props: {
-		allowedDates: {
-			default: () => (value) => {
-				const day = parseInt(value.split('-')[2], 10);
-				return [5, 10, 15, 20, 25].includes(day);
-			}
-		}
-	},
-	template: `<div style='max-width: 320px'><farm-input-datepicker position="bottom" :allowed-dates="allowedDates" inputId="input-custom-id-1" v-model="date" /></div>`,
+	template: `<div style='max-width: 320px'>
+		<farm-input-datepicker position="bottom" :allowed-days="allowedDays" inputId="input-custom-id-1" v-model="date" />
+	</div>`,
 });
 
 export const WithInitialMonth = () => ({

--- a/src/components/DatePicker/DatePicker.stories.js
+++ b/src/components/DatePicker/DatePicker.stories.js
@@ -24,7 +24,7 @@ export const Primary = () => ({
 	},
 	template: `<div style='max-width: 320px'>
         <farm-input-datepicker inputId="input-custom-id-0" v-model="date" />
-		{{ date }}
+		date: {{ date }}
     </div>`,
 });
 

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -1,26 +1,66 @@
 <template>
-	<farm-contextmenu stay-open v-model="menuField" ref="contextmenu" maxHeight="auto" popup-width="320"
-		:bottom="position === 'bottom'" :top="position === 'top'">
-
-		<VueDatePicker calendar-class-name="dp-custom-calendar" inline auto-apply model-type="yyyy-MM-dd"
-			v-model="dateField" :min-date="minDate" :max-date="maxDate" :allowed-dates="allowedDaysList" />
+	<farm-contextmenu
+		stay-open
+		v-model="menuField"
+		ref="contextmenu"
+		maxHeight="auto"
+		popup-width="320"
+		:bottom="position === 'bottom'"
+		:top="position === 'top'"
+	>
+		<VueDatePicker
+			calendar-class-name="dp-custom-calendar"
+			inline
+			auto-apply
+			model-type="yyyy-MM-dd"
+			locale="pt-BR"
+			v-model="dateField"
+			:min-date="minDate"
+			:max-date="maxDate"
+			:allowed-dates="allowedDaysList"
+			:day-names="['S', 'T', 'Q', 'Q', 'S', 'S', 'D']"
+		/>
 
 		<div class="picker__actions">
-			<farm-btn plain title="Limpar" color="primary" :disabled="isDisabled" @click="clear">
+			<farm-btn
+				plain
+				title="Limpar"
+				color="primary"
+				:disabled="isDisabled"
+				@click="clear"
+			>
 				Limpar
 			</farm-btn>
-			<farm-btn outlined class="btn-cancel" title="Cancelar" @click="closeDatepicker">
+			<farm-btn
+				outlined
+				class="btn-cancel"
+				title="Cancelar"
+				@click="closeDatepicker"
+			>
 				Cancelar
 			</farm-btn>
 
-			<farm-btn class="ml-2" title="Confirmar" :disabled="isDateFieldDisabled" @click="save()">
+			<farm-btn
+				class="ml-2"
+				title="Confirmar"
+				:disabled="isDateFieldDisabled"
+				@click="save()"
+			>
 				Confirmar <farm-icon>check</farm-icon>
 			</farm-btn>
 		</div>
-		<template v-slot:activator="{ }">
-			<farm-textfield-v2 icon="calendar" v-model="fieldRange" autocomplete="off" ref="inputCalendar"
-				:readonly="readonly" :mask="`${readonly ? '' : '##/##/####'}`" :id="inputId"
-				:rules="[checkDateValid, checkMax, checkMin, checkRequire, checkIsInAllowedDates]" @keyup="keyUpInput" />
+		<template v-slot:activator="{}">
+			<farm-textfield-v2
+				icon="calendar"
+				v-model="fieldRange"
+				autocomplete="off"
+				ref="inputCalendar"
+				:readonly="readonly"
+				:mask="`${readonly ? '' : '##/##/####'}`"
+				:id="inputId"
+				:rules="[checkDateValid, checkMax, checkMin, checkRequire, checkIsInAllowedDates]"
+				@keyup="keyUpInput"
+			/>
 		</template>
 	</farm-contextmenu>
 </template>
@@ -34,7 +74,7 @@ const revertDate = (oldDate: string): string => {
 	const newDate = arr[2] + '/' + arr[1] + '/' + arr[0];
 
 	return newDate;
-}
+};
 import { PropType } from 'vue';
 import {
 	defaultFormat as dateDefaultFormatter,
@@ -93,7 +133,7 @@ export default {
 		},
 		allowedDatesValidator: {
 			type: Function,
-			default: () => true
+			default: () => true,
 		},
 		/**
 		 * Current month/year to show when opened
@@ -115,7 +155,6 @@ export default {
 		},
 	},
 	data() {
-
 		return {
 			internalPickerDate: this.pickerDate,
 			menuField: false,
@@ -254,9 +293,9 @@ export default {
 		},
 		allowedDaysList() {
 			if (this.allowedDays) {
-				return this.allowedDays.map(day => new Date().setDate(day))
+				return this.allowedDays.map(day => new Date().setDate(day));
 			}
-		}
+		},
 	},
 };
 </script>

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -19,6 +19,7 @@
 			:max-date="maxDate"
 			:allowed-dates="allowedDaysList"
 			:day-names="['S', 'T', 'Q', 'Q', 'S', 'S', 'D']"
+			:start-date="internalPickerDate"
 		/>
 
 		<div class="picker__actions">
@@ -65,27 +66,12 @@
 	</farm-contextmenu>
 </template>
 <script lang="ts">
-const revertDate = (oldDate: string): string => {
-	if (!oldDate) {
-		return '';
-	}
-	const arr = oldDate.split('-');
-	// Concatenate each part in reverse order
-	const newDate = arr[2] + '/' + arr[1] + '/' + arr[0];
-
-	return newDate;
-};
 import { PropType } from 'vue';
-import {
-	defaultFormat as dateDefaultFormatter,
-	convertDate,
-	checkDateValid,
-} from '../../helpers/date';
+import { convertDate, checkDateValid, revertDate } from '../../helpers/date';
 import { formatDatePickerHeader } from '../../helpers';
 /**
  * Componente de input com datepicker para data
  */
-
 export default {
 	name: 'farm-input-datepicker',
 	props: {
@@ -221,7 +207,6 @@ export default {
 	},
 	methods: {
 		save() {
-			// this.inputVal = this.formatDateRange(this.dateField);
 			this.inputVal = this.dateField;
 			this.menuField = false;
 			this.fieldRange = revertDate(this.dateField);

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -2,19 +2,21 @@
 	<farm-contextmenu stay-open v-model="menuField" ref="contextmenu" maxHeight="auto" popup-width="320"
 		:bottom="position === 'bottom'" :top="position === 'top'">
 
-		<VueDatePicker inline auto-apply model-type="yyyy-MM-dd" v-model="dateField" :min-date="minDate" :max-date="maxDate"
-			:allowed-dates="allowedDaysList" />
+		<VueDatePicker calendar-class-name="dp-custom-calendar" inline auto-apply model-type="yyyy-MM-dd"
+			v-model="dateField" :min-date="minDate" :max-date="maxDate" :allowed-dates="allowedDaysList" />
 
-		<farm-btn plain title="Limpar" color="primary" :disabled="isDisabled" @click="clear">
-			Limpar
-		</farm-btn>
-		<farm-btn outlined class="btn-cancel" title="Cancelar" @click="closeDatepicker">
-			Cancelar
-		</farm-btn>
+		<div class="picker__actions">
+			<farm-btn plain title="Limpar" color="primary" :disabled="isDisabled" @click="clear">
+				Limpar
+			</farm-btn>
+			<farm-btn outlined class="btn-cancel" title="Cancelar" @click="closeDatepicker">
+				Cancelar
+			</farm-btn>
 
-		<farm-btn class="ml-2" title="Confirmar" :disabled="isDateFieldDisabled" @click="save()">
-			Confirmar <farm-icon>check</farm-icon>
-		</farm-btn>
+			<farm-btn class="ml-2" title="Confirmar" :disabled="isDateFieldDisabled" @click="save()">
+				Confirmar <farm-icon>check</farm-icon>
+			</farm-btn>
+		</div>
 		<template v-slot:activator="{ }">
 			<farm-textfield-v2 icon="calendar" v-model="fieldRange" autocomplete="off" ref="inputCalendar"
 				:readonly="readonly" :mask="`${readonly ? '' : '##/##/####'}`" :id="inputId"

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -2,7 +2,8 @@
 	<farm-contextmenu stay-open v-model="menuField" ref="contextmenu" maxHeight="auto" popup-width="320"
 		:bottom="position === 'bottom'" :top="position === 'top'">
 
-		<VueDatePicker inline auto-apply model-type="yyyy-MM-dd" v-model="dateField" />
+		<VueDatePicker inline auto-apply model-type="yyyy-MM-dd" v-model="dateField" :min-date="minDate" :max-date="maxDate"
+			:allowed-dates="allowedDaysList" />
 
 		<farm-btn plain title="Limpar" color="primary" :disabled="isDisabled" @click="clear">
 			Limpar
@@ -14,7 +15,7 @@
 		<farm-btn class="ml-2" title="Confirmar" :disabled="isDateFieldDisabled" @click="save()">
 			Confirmar <farm-icon>check</farm-icon>
 		</farm-btn>
-		<template v-slot:activator="{ }">{{ fieldRange }}
+		<template v-slot:activator="{ }">
 			<farm-textfield-v2 icon="calendar" v-model="fieldRange" autocomplete="off" ref="inputCalendar"
 				:readonly="readonly" :mask="`${readonly ? '' : '##/##/####'}`" :id="inputId"
 				:rules="[checkDateValid, checkMax, checkMin, checkRequire, checkIsInAllowedDates]" @keyup="keyUpInput" />
@@ -23,7 +24,7 @@
 </template>
 <script lang="ts">
 const revertDate = (oldDate: string): string => {
-	if(!oldDate) {
+	if (!oldDate) {
 		return '';
 	}
 	const arr = oldDate.split('-');
@@ -45,9 +46,6 @@ import { formatDatePickerHeader } from '../../helpers';
 
 export default {
 	name: 'farm-input-datepicker',
-	components: {
-		//	VDatePicker,
-	},
 	props: {
 		/**
 		 * Input's id
@@ -85,11 +83,15 @@ export default {
 			default: 'bottom',
 		},
 		/**
-		 * Allowed dates to be selected and validated
+		 * Allowed days to be selected and validated
 		 */
-		allowedDates: {
+		allowedDays: {
+			type: Array,
+			default: () => null,
+		},
+		allowedDatesValidator: {
 			type: Function,
-			default: () => true,
+			default: () => true
 		},
 		/**
 		 * Current month/year to show when opened
@@ -111,8 +113,6 @@ export default {
 		},
 	},
 	data() {
-		// const s = this.formatDateRange(this.modelValue);
-		// const s = convertDate(this.modelValue);
 
 		return {
 			internalPickerDate: this.pickerDate,
@@ -158,15 +158,13 @@ export default {
 					return true;
 				}
 
-				return this.allowedDates(dateSelected) || 'Data inválida';
+				return this.allowedDatesValidator(dateSelected) || 'Data inválida';
 			},
 		};
 	},
 	watch: {
 		modelValue(newValue) {
 			this.dateField = newValue;
-			// this.fieldRange = newValue;
-			//			console.log(newValue, this.fieldRange);
 		},
 		fieldRange(newValue) {
 			if (!newValue) {
@@ -242,6 +240,21 @@ export default {
 			}
 			return true;
 		},
+		minDate() {
+			if (this.min) {
+				return new Date(this.min);
+			}
+		},
+		maxDate() {
+			if (this.max) {
+				return new Date(this.max);
+			}
+		},
+		allowedDaysList() {
+			if (this.allowedDays) {
+				return this.allowedDays.map(day => new Date().setDate(day))
+			}
+		}
 	},
 };
 </script>

--- a/src/components/DatePicker/customDatePicker.scss
+++ b/src/components/DatePicker/customDatePicker.scss
@@ -1,0 +1,61 @@
+.dp__main {
+    font-family: inherit;
+    justify-content: center;
+
+    :deep(.dp__cell_inner) {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--farm-neutral-darken);
+        padding: 0;
+        width: 32px;
+
+        &.dp__cell_offset {
+            color: var(--farm-gray-lighten);
+        }
+
+        &.dp__cell_disabled {
+            color: var(--farm-gray-lighten);
+        }
+    }
+
+    :deep(.dp__menu) {
+        border: 0;
+    }
+
+    :deep(.dp--tp-wrap) {
+        display: none;
+    }
+
+    :deep(.dp__active_date) {
+        background-color: var(--farm-primary-base);
+        color: white;
+    }
+
+    :deep(.dp__today) {
+        border: 1px solid var(--farm-primary-base);
+    }
+
+    :deep(.dp__calendar_header_separator) {
+        display: none;
+    }
+
+    :deep(.dp__calendar_header) {
+        color: var(--farm-neutral-darken);
+        font-size: 16px;
+        font-weight: 700;
+        margin-top: 16px;
+    }
+
+    :deep(.dp__calendar_row) {
+        margin: 0;
+    }
+
+}
+
+.picker__actions {
+    padding: 16px 8px 0;
+    border-top: 1px solid var(--farm-stroke-base);
+    margin-bottom: 16px;
+    margin-left: -4px;
+    margin-right: -4px;
+}

--- a/src/components/TextFieldV2/TextFieldV2.vue
+++ b/src/components/TextFieldV2/TextFieldV2.vue
@@ -189,9 +189,9 @@ export default {
 		const showErrorText = computed(() => hasError.value && isTouched.value && isBlured.value);
 
 		watch(
-			() => props.value,
+			() => props.modelValue,
 			() => {
-				innerValue.value = props.value;
+				innerValue.value = props.modelValue;
 				validate(innerValue.value);
 			}
 		);

--- a/src/examples/Table.stories.js
+++ b/src/examples/Table.stories.js
@@ -1,7 +1,6 @@
 // import { withDesign } from 'storybook-addon-designs';
 import { VDataTable } from 'vuetify/labs/components';
-import DataTableEmptyWrapper from '../components/DataTableEmptyWrapper';
-import DataTablePaginator from '../components/DataTablePaginator';
+import { ref, watch } from 'vue';
 
 const headers = [
 	{
@@ -92,7 +91,7 @@ export const TableSampleDataWithCheckbox = () => ({
 			selectedItems: [],
 		};
 	},
-	template: `<div>
+	template: `<div>{{ selectedItems }}
 	<v-data-table
         hide-default-footer
 		id="v-data-table--default"
@@ -106,7 +105,7 @@ export const TableSampleDataWithCheckbox = () => ({
 });
 
 export const TableSampleLocalPagination = () => ({
-	components: { 'v-data-table': VDataTable, DataTableEmptyWrapper, DataTablePaginator },
+	components: { 'v-data-table': VDataTable },
 	data() {
 		return {
 			headers,
@@ -159,7 +158,7 @@ export const TableSampleLocalPagination = () => ({
 });
 
 export const TableSampleDataWithFarmCheckbox = () => ({
-
+	components: { 'v-data-table': VDataTable },
 	data() {
 		return {
 			headers,
@@ -168,18 +167,14 @@ export const TableSampleDataWithFarmCheckbox = () => ({
 				{ id: 2, name: 'name 2' },
 				{ id: 3, name: 'name 3' },
 			],
-			selectedItems: [2],
-			item: {
-				value: 2
-			}
+			selectedItems: [],
 		};
 	},
 	methods: {
 		onSelect({ item }) {
-			console.log(9999999);
 			if (item.id === 2)
 				this.selectedItems = [...this.selectedItems].filter(
-					innerItem => innerItem.value !== 2
+					innerItem => innerItem.id !== 2
 				);
 		},
 		isItemSelected(item) {
@@ -197,7 +192,7 @@ export const TableSampleDataWithFarmCheckbox = () => ({
 		@item-selected="onSelect"
 	>
 		<template v-slot:item.data-table-select="{ isSelected, select, item }">
-			<farm-checkbox :value="item.value" :checked="isItemSelected(item)" @change="select($event)"/>
+			<farm-checkbox :value="item.id" :checked="isItemSelected(item)" @input="select($event)"/>
 		</template>
     </v-data-table>
 	</div>`,

--- a/src/helpers/date.ts
+++ b/src/helpers/date.ts
@@ -13,6 +13,14 @@ export const convertDate = (data) => {
 	return newdate;
 };
 
+export const revertDate = (data: string): string => {
+	if(!data) {
+		return '';
+	}
+	let newdate = data.split("-").reverse().join("/");
+	return newdate;
+};
+
 
 const checkLength = (value, length) => {
 	return parseInt(value.length, 10) === length;


### PR DESCRIPTION
Esse PR contém uma nova implementação do farm-input-datepicker usando um componente standalone de datepicker:
https://vue3datepicker.com/

O componente do Vuetify 3 ainda está bem cru, faltando muitas funcionalidades. Para dar andamento ao processo de migração, adotei esse componente mantendo o mesmo comportamento, API do componente praticamente igual (ver o [migration guide](https://docs.google.com/document/d/1dMUzd1NmNX68-_1ltpbBMmeVnZ3h0kmN08oX1k9VxbA/edit), tive que fazer uma pequena mudança em uma prop chamada _allowed-dates_) e identidade visual bem semelhante.



https://github.com/Farm-Investimentos/front-mfe-components/assets/84783765/70dd1719-9099-4fcb-b4df-245868fa7617

