### PR TITLE
GI-692

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -87,6 +87,7 @@ export default defineComponent({
 			window.removeEventListener('keyup', escHandler);
 			inputValue.value = false;
 			emit('input', false);
+			emit('onClose');
 		};
 
 		watch(


### PR DESCRIPTION
Correction of the error when clicking outside the modal does 
not call the same function that is passed on the close button and the X button.