### PR TITLE
fix: FRONT-578

### DIFF
--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -4,6 +4,10 @@
 .farm-tooltip {
 	display: inline-block;
 	position: relative;
+
+	&__activator {
+		display: inline-block;
+	}
 }
 
 .farm-tooltip__popup {
@@ -13,7 +17,6 @@
 			background-color: rgba(themeColor($color), 0.95);
 		}
 	}
-
 }
 
 .farm-tooltip__popup {

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -1,7 +1,7 @@
 <template>
 	<span :class="{ 'farm-tooltip': true }" ref="parent">
-		<span @mouseover="onOver" @mouseout="onOut" ref="activator">
-			<slot name="activator"></slot>
+		<span class="farm-tooltip__activator" ref="activator" @mouseover="onOver" @mouseout="onOut">
+			<slot name="activator" />
 		</span>
 
 		<span
@@ -15,7 +15,7 @@
 			:style="styles"
 			@mouseout="onOut"
 		>
-			<slot></slot>
+			<slot />
 		</span>
 	</span>
 </template>


### PR DESCRIPTION
Make activator wrapper occupy whole part of farm-tooltip, so the tooltip corrrectly hides when mouse leaves it

[FRONT-578](https://dev-farm.atlassian.net/browse/FRONT-578)

[FRONT-578]: https://dev-farm.atlassian.net/browse/FRONT-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ