### PR TITLE
Feat: SO-500

### DIFF
--- a/src/components/Logger/LoggerItem/LoggerItem.scss
+++ b/src/components/Logger/LoggerItem/LoggerItem.scss
@@ -69,7 +69,7 @@
 	&--horizontal {
 		flex-direction: column;
 		height: auto;
-		width: 158px;
+		max-width: 230px;
 
 		> div {
 			align-items: center;


### PR DESCRIPTION
This pull request includes a small change to the `LoggerItem.scss` file. The change adjusts the maximum width for the `LoggerItem` component when it is in horizontal mode.

* [`src/components/Logger/LoggerItem/LoggerItem.scss`](diffhunk://#diff-5c47b18640abbd09600dacbc8550677fe5497f5203b301d78539e510e6993850L72-R72): Changed the width from a fixed 158px to a max-width of 230px for better responsiveness.