### PR TITLE
fix: atualizado o atributo alt para aria-label no teste do FilterEmptyState

### DIFF
--- a/src/components/FilterEmptyState/__tests__/FilterEmptyState.test.js
+++ b/src/components/FilterEmptyState/__tests__/FilterEmptyState.test.js
@@ -125,6 +125,6 @@ describe('FilterEmptyState', () => {
 
 		const img = wrapper.find('.filter-empty-state__image');
 		expect(img.exists()).toBe(true);
-		expect(img.attributes('alt')).toBe('Imagem referente a filtro vazio');
+		expect(img.attributes('aria-label')).toBe('Imagem referente a filtro vazio');
 	});
 });


### PR DESCRIPTION
Correção no teste do FilterEmptyState.test.js  no atributo **alt** para **aria-label** na imagem de estado vazio.
